### PR TITLE
fix(#9): Codex rollout usage — incremental deltas, reasoning dedup, local TZ

### DIFF
--- a/src/quota/codex-session.ts
+++ b/src/quota/codex-session.ts
@@ -205,47 +205,60 @@ export class CodexSessionQuotaSource implements QuotaSource {
   /**
    * Aggregate daily token usage across recent Codex sessions.
    *
-   * For each session file we read the most recent token_count event and take
-   * its `total_token_usage` (the cumulative count for that session). We then
-   * bucket these by the event's date. `requests` counts how many token_count
-   * events fired that day (a proxy for API turns). Only the last `days` days
-   * are scanned to bound work, since the session tree grows large over time.
+   * Computes consumption as the DELTA between consecutive token_count events'
+   * cumulative totals (not the raw cumulative value), so a session spanning
+   * multiple days attributes each day's increment to that day rather than
+   * dumping everything onto the last day (PRD §7.1 / §14.2). Buckets use the
+   * user's LOCAL timezone, not UTC. output_tokens already includes reasoning
+   * tokens, so reasoning is NOT added again.
    *
+   * Only the last `days` days are scanned (file mtime pre-filter + tail read).
    * Returns records sorted oldest-first.
    */
   async fetchUsage(days = 7): Promise<CodexUsageRecord[]> {
     const cutoffMs = this.now().getTime() - days * 86_400_000;
 
-    // Pre-filter by file mtime so we never open the (potentially huge) older
-    // files. A session active in the last `days` days has a recent mtime.
     const candidates = await collectRolloutFilesWithMtime(this.sessionsDir);
     const recent = candidates.filter(([, mtimeMs]) => mtimeMs >= cutoffMs);
 
-    // date(YYYY-MM-DD) → aggregated accumulator
+    // local-date(YYYY-MM-DD) → accumulator
     const byDay = new Map<
       string,
       { requests: number; input: number; output: number; total: number; cached: number }
     >();
 
-    // Process sequentially: each readTail allocates a 512KB buffer, and the
-    // session tree can contain dozens of files. Sequential keeps the peak
-    // memory flat and is still fast (tail reads are tiny).
     for (const [file] of recent) {
-      const latest = await readLatestTokenCount(file);
-      if (!latest) continue;
+      const series = await readTokenCountSeries(file);
+      if (series.length === 0) continue;
 
-      // Second guard: mtime is heuristic; verify the event is within window.
-      if (latest.timestampMs < cutoffMs) continue;
+      // Walk consecutive pairs; each delta belongs to the LATER event's day.
+      // The first event in the (tail-limited) series has no predecessor here,
+      // so its own total is treated as the baseline and skipped — we only count
+      // increments, which keeps totals honest even when the tail doesn't start
+      // at the session's very first event.
+      for (let i = 1; i < series.length; i++) {
+        const prev = series[i - 1];
+        const curr = series[i];
+        if (curr.timestampMs < cutoffMs) continue;
 
-      const day = new Date(latest.timestampMs).toISOString().slice(0, 10);
-      const usage = latest.info.total_token_usage ?? {};
-      const acc = byDay.get(day) ?? { requests: 0, input: 0, output: 0, total: 0, cached: 0 };
-      acc.requests += 1; // one session contributes one "final" count
-      acc.input += usage.input_tokens ?? 0;
-      acc.output += (usage.output_tokens ?? 0) + (usage.reasoning_output_tokens ?? 0);
-      acc.total += usage.total_tokens ?? 0;
-      acc.cached += usage.cached_input_tokens ?? 0;
-      byDay.set(day, acc);
+        const pu = prev.info.total_token_usage ?? {};
+        const cu = curr.info.total_token_usage ?? {};
+        const dInput = Math.max(0, (cu.input_tokens ?? 0) - (pu.input_tokens ?? 0));
+        // output_tokens already includes reasoning_output_tokens — do NOT add it again.
+        const dOutput = Math.max(0, (cu.output_tokens ?? 0) - (pu.output_tokens ?? 0));
+        const dTotal = Math.max(0, (cu.total_tokens ?? 0) - (pu.total_tokens ?? 0));
+        const dCached = Math.max(0, (cu.cached_input_tokens ?? 0) - (pu.cached_input_tokens ?? 0));
+        if (dTotal === 0 && dInput === 0 && dOutput === 0) continue;
+
+        const day = localDateKey(curr.timestampMs);
+        const acc = byDay.get(day) ?? { requests: 0, input: 0, output: 0, total: 0, cached: 0 };
+        acc.requests += 1;
+        acc.input += dInput;
+        acc.output += dOutput;
+        acc.total += dTotal;
+        acc.cached += dCached;
+        byDay.set(day, acc);
+      }
     }
 
     return Array.from(byDay.entries())
@@ -361,15 +374,15 @@ interface TokenCountHit {
 }
 
 /**
- * Read the most recent token_count event's `info` block from a rollout file.
- * Used for daily usage aggregation. Mirrors readLatestRateLimits' tail-scan.
+ * Read ALL token_count events (within the tail) as a time-ordered series.
+ * Used for incremental daily usage: we diff cumulative totals between
+ * consecutive events to attribute consumption to the correct local day.
  */
-async function readLatestTokenCount(file: string): Promise<TokenCountHit | null> {
+async function readTokenCountSeries(file: string): Promise<TokenCountHit[]> {
   const text = await readTail(file, TAIL_BYTES);
-  if (text === null) return null;
+  if (text === null) return [];
 
-  let best: TokenCountHit | null = null;
-
+  const hits: TokenCountHit[] = [];
   const lines = text.split('\n');
   const start = Math.max(0, lines.length - TAIL_LINES);
   for (let i = start; i < lines.length; i++) {
@@ -385,16 +398,16 @@ async function readLatestTokenCount(file: string): Promise<TokenCountHit | null>
 
     const payload = event.payload as TokenCountPayload | undefined;
     const info = payload?.info;
-    if (!info || (!info.total_token_usage && !info.last_token_usage)) continue;
+    if (!info || !info.total_token_usage) continue;
 
     const ts = event.timestamp ? Date.parse(event.timestamp) : NaN;
     const timestampMs = Number.isNaN(ts) ? 0 : ts;
-    if (!best || timestampMs >= best.timestampMs) {
-      best = { timestampMs, info };
-    }
+    hits.push({ timestampMs, info });
   }
 
-  return best;
+  // Earliest-first so deltas compute naturally.
+  hits.sort((a, b) => a.timestampMs - b.timestampMs);
+  return hits;
 }
 
 /**
@@ -496,3 +509,22 @@ function round1(value: number): number {
   if (!Number.isFinite(value)) return 0;
   return Math.round(value * 10) / 10;
 }
+
+/**
+ * Format a Unix-ms timestamp as a LOCAL-timezone YYYY-MM-DD key (not UTC).
+ * `en-CA` locale yields ISO-order dates without an explicit time zone, and
+ * without `timeZone` it uses the runtime's local zone — so daily buckets align
+ * with the user's calendar day (PRD §7.1).
+ */
+const LOCAL_DATE_FMT = new Intl.DateTimeFormat('en-CA', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+function localDateKey(timestampMs: number): string {
+  return LOCAL_DATE_FMT.format(new Date(timestampMs));
+}
+
+/** Exported for testing the local-timezone bucketing behavior. */
+export { localDateKey as _localDateKeyForTest };

--- a/tests/quota/codex-session.test.ts
+++ b/tests/quota/codex-session.test.ts
@@ -293,26 +293,17 @@ describe('CodexSessionQuotaSource.fetchUsage', () => {
     await rm(dir, { recursive: true, force: true });
   });
 
-  it('aggregates cumulative token usage per day across sessions', async () => {
-    // Two sessions on the same day → their totals sum into one day bucket.
+  it('computes daily usage from incremental deltas, not raw cumulative totals', async () => {
+    // One session with two events: cumulative total grows 1000 → 3500.
+    // The day's consumption is the DELTA (2500), not the final total (3500).
     const sessionDir = join(dir, '2026', '07', '30');
     await mkdir(sessionDir, { recursive: true });
     await writeFile(
       join(sessionDir, 'rollout-a.jsonl'),
-      usageLine('2026-07-30T10:00:00Z', {
-        input_tokens: 1000,
-        output_tokens: 200,
-        total_tokens: 1200,
-        cached_input_tokens: 100,
-      }) + '\n',
-    );
-    await writeFile(
-      join(sessionDir, 'rollout-b.jsonl'),
-      usageLine('2026-07-30T11:00:00Z', {
-        input_tokens: 3000,
-        output_tokens: 500,
-        total_tokens: 3500,
-      }) + '\n',
+      [
+        usageLine('2026-07-30T10:00:00Z', { input_tokens: 1000, output_tokens: 200, total_tokens: 1200, cached_input_tokens: 100 }),
+        usageLine('2026-07-30T11:00:00Z', { input_tokens: 3000, output_tokens: 500, total_tokens: 3500, cached_input_tokens: 150 }),
+      ].join('\n') + '\n',
     );
 
     const source = new CodexSessionQuotaSource({ sessionsDir: dir, now: () => FIXED_NOW });
@@ -321,29 +312,55 @@ describe('CodexSessionQuotaSource.fetchUsage', () => {
     expect(records).toHaveLength(1);
     const day = records[0];
     expect(day.date).toBe('2026-07-30');
-    expect(day.requests).toBe(2); // two sessions
-    expect(day.input_tokens).toBe(4000);
-    expect(day.output_tokens).toBe(700);
-    expect(day.total_tokens).toBe(4700);
-    expect(day.cached_input_tokens).toBe(100);
+    expect(day.requests).toBe(1); // one delta (between the two events)
+    // Deltas: input 3000-1000=2000, output 500-200=300, total 3500-1200=2300, cached 150-100=50
+    expect(day.input_tokens).toBe(2000);
+    expect(day.output_tokens).toBe(300);
+    expect(day.total_tokens).toBe(2300);
+    expect(day.cached_input_tokens).toBe(50);
   });
 
-  it('adds reasoning_output_tokens into output_tokens', async () => {
+  it('does NOT add reasoning_output_tokens into output (already included)', async () => {
+    // output_tokens already contains reasoning; the delta must not add it again.
     const sessionDir = join(dir, '2026', '07', '30');
     await mkdir(sessionDir, { recursive: true });
     await writeFile(
       join(sessionDir, 'rollout-reason.jsonl'),
-      usageLine('2026-07-30T10:00:00Z', {
-        output_tokens: 100,
-        reasoning_output_tokens: 50,
-        total_tokens: 150,
-      }) + '\n',
+      [
+        usageLine('2026-07-30T10:00:00Z', { output_tokens: 100, reasoning_output_tokens: 40, total_tokens: 100 }),
+        usageLine('2026-07-30T11:00:00Z', { output_tokens: 300, reasoning_output_tokens: 120, total_tokens: 300 }),
+      ].join('\n') + '\n',
     );
 
     const source = new CodexSessionQuotaSource({ sessionsDir: dir, now: () => FIXED_NOW });
     const records = await source.fetchUsage(7);
 
-    expect(records[0].output_tokens).toBe(150); // 100 + 50
+    // output delta = 300-100 = 200 (NOT 200 + reasoning delta 80)
+    expect(records[0].output_tokens).toBe(200);
+  });
+
+  it('splits a cross-day session into the correct days via deltas', async () => {
+    // A session active across two days: day1 event total=1000, day2 event total=3000.
+    // day1 gets nothing (no predecessor before it in the tail), day2 gets delta 2000.
+    const sessionDir = join(dir, '2026', '07', '29');
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      join(sessionDir, 'rollout-cross.jsonl'),
+      [
+        usageLine('2026-07-29T22:00:00Z', { total_tokens: 1000, input_tokens: 800, output_tokens: 200 }),
+        usageLine('2026-07-30T02:00:00Z', { total_tokens: 3000, input_tokens: 2600, output_tokens: 400 }),
+      ].join('\n') + '\n',
+    );
+
+    const source = new CodexSessionQuotaSource({ sessionsDir: dir, now: () => FIXED_NOW });
+    const records = await source.fetchUsage(7);
+
+    // Only day2 (the delta target) appears; day1's baseline is not counted.
+    const dates = records.map((r) => r.date);
+    expect(dates).toContain('2026-07-30');
+    expect(dates).not.toContain('2026-07-29');
+    const day2 = records.find((r) => r.date === '2026-07-30')!;
+    expect(day2.total_tokens).toBe(2000);
   });
 
   it('skips files whose mtime is older than the window', async () => {
@@ -354,15 +371,20 @@ describe('CodexSessionQuotaSource.fetchUsage', () => {
 
     await writeFile(
       join(recentDir, 'rollout-recent.jsonl'),
-      usageLine('2026-07-30T10:00:00Z', { input_tokens: 100, total_tokens: 100 }) + '\n',
+      [
+        usageLine('2026-07-30T09:00:00Z', { total_tokens: 50 }),
+        usageLine('2026-07-30T10:00:00Z', { total_tokens: 100, input_tokens: 50 }),
+      ].join('\n') + '\n',
     );
     const oldFile = join(oldDir, 'rollout-old.jsonl');
     await writeFile(
       oldFile,
-      usageLine('2026-06-01T10:00:00Z', { input_tokens: 999, total_tokens: 999 }) + '\n',
+      [
+        usageLine('2026-06-01T09:00:00Z', { total_tokens: 500 }),
+        usageLine('2026-06-01T10:00:00Z', { total_tokens: 999, input_tokens: 499 }),
+      ].join('\n') + '\n',
     );
 
-    // Force the old file's mtime to 30 days ago so it falls outside the 7d window.
     const thirtyDaysAgo = new Date('2026-06-30T12:00:00Z');
     await utimes(oldFile, thirtyDaysAgo, thirtyDaysAgo);
 
@@ -379,8 +401,15 @@ describe('CodexSessionQuotaSource.fetchUsage', () => {
     await mkdir(day1, { recursive: true });
     await mkdir(day2, { recursive: true });
 
-    await writeFile(join(day2, 'rollout-a.jsonl'), usageLine('2026-07-30T10:00:00Z', { total_tokens: 1 }) + '\n');
-    await writeFile(join(day1, 'rollout-b.jsonl'), usageLine('2026-07-28T10:00:00Z', { total_tokens: 2 }) + '\n');
+    // Each file has two events so a delta is produced.
+    await writeFile(
+      join(day1, 'rollout-b.jsonl'),
+      [usageLine('2026-07-28T09:00:00Z', { total_tokens: 0 }), usageLine('2026-07-28T10:00:00Z', { total_tokens: 2, input_tokens: 2 })].join('\n') + '\n',
+    );
+    await writeFile(
+      join(day2, 'rollout-a.jsonl'),
+      [usageLine('2026-07-30T09:00:00Z', { total_tokens: 0 }), usageLine('2026-07-30T10:00:00Z', { total_tokens: 1, input_tokens: 1 })].join('\n') + '\n',
+    );
 
     const source = new CodexSessionQuotaSource({ sessionsDir: dir, now: () => FIXED_NOW });
     const records = await source.fetchUsage(7);
@@ -401,5 +430,19 @@ describe('CodexSessionQuotaSource.fetchUsage', () => {
     const records = await source.fetchUsage(7);
 
     expect(records).toHaveLength(0);
+  });
+
+  it('buckets by local timezone, not UTC', async () => {
+    // localDateKey uses the system's local timezone via Intl en-CA.
+    // An event at 2026-07-30T23:30 UTC: in UTC+N zones it falls on 07-31 local,
+    // in UTC-N zones it stays 07-30. Either way it must NOT be a raw UTC slice
+    // when the local zone differs from UTC — we assert it equals what the local
+    // Date says the Y/M/D is, proving it's local-zoned (not toISOString).
+    const { _localDateKeyForTest } = await import('../../src/quota/codex-session.js');
+    const ts = Date.parse('2026-07-30T23:30:00Z');
+    const expected = new Date(ts).toLocaleString('en-CA', { year: 'numeric', month: '2-digit', day: '2-digit' });
+    expect(_localDateKeyForTest(ts)).toBe(expected);
+    // And it's a valid YYYY-MM-DD shape.
+    expect(_localDateKeyForTest(ts)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 });


### PR DESCRIPTION
Closes #9

Fixes the three P0 statistics bugs in `codex-session.ts` `fetchUsage`:

1. **Cross-day attribution**: sessions no longer dump all usage onto the last day. Now reads the full token_count event series and computes **deltas** between consecutive cumulative totals, attributing each increment to the later event's day.
2. **Reasoning dedup**: `reasoning_output_tokens` is no longer added to `output_tokens` (the App Server's output already includes reasoning — adding it again double-counted).
3. **Local timezone bucketing**: uses `Intl.DateTimeFormat` (en-CA) instead of UTC slicing, so near-midnight sessions attribute to the correct calendar day.

## Verification
- Real data smoke: daily totals dropped from implausible billions (cumulative) to realistic millions (incremental) — e.g. 97.77M on the heaviest day vs the old ~12B.
- Tests rewritten: deltas, cross-day split, reasoning dedup, local-TZ bucketing, mtime filter, sorting.

\`npm run typecheck && lint && test\` — 75 tests pass.