### PR TITLE
fix(#10): observedAt reflects real observation time

### DIFF
--- a/src/quota/codex-session.ts
+++ b/src/quota/codex-session.ts
@@ -38,6 +38,8 @@ export interface QuotaSnapshot {
   provider: 'codex';
   displayName: string;
   fetchedAt: number;
+  /** When the data was actually observed (latest event timestamp), in ms. */
+  observedAt?: number;
   buckets: QuotaBucket[];
   error?: { message: string; code?: string };
 }
@@ -191,6 +193,7 @@ export class CodexSessionQuotaSource implements QuotaSource {
         provider: 'codex',
         displayName: this.displayName,
         fetchedAt,
+        observedAt: best.timestampMs,
         buckets,
       };
     } catch (error) {

--- a/src/quota/providers/codex.ts
+++ b/src/quota/providers/codex.ts
@@ -230,7 +230,10 @@ async function rolloutFallback(
       providerId: PROVIDER_ID,
       status: 'ready',
       fetchedAt,
-      observedAt: fetchedAt,
+      // observedAt = when the rollout data was actually generated (the latest
+      // rate_limits event time), NOT when we read it. This is what makes a
+      // stale snapshot honestly report its age (PRD §8.1 / issue #10).
+      observedAt: snap.observedAt != null ? new Date(snap.observedAt).toISOString() : fetchedAt,
       source: ROLLOUT_SOURCE,
       plan: { name: null, accountLabel: null },
       buckets,

--- a/tests/quota/codex-session.test.ts
+++ b/tests/quota/codex-session.test.ts
@@ -99,6 +99,10 @@ describe('CodexSessionQuotaSource', () => {
     expect(snapshot.error).toBeUndefined();
     expect(snapshot.buckets).toHaveLength(2);
 
+    // observedAt reflects the latest event's time, not the read time (issue #10).
+    expect(snapshot.observedAt).toBe(Date.parse('2026-07-30T10:05:00Z'));
+    expect(snapshot.observedAt).not.toBe(FIXED_NOW.getTime());
+
     const fiveHour = snapshot.buckets[0];
     expect(fiveHour.label).toBe('5-hour');
     expect(fiveHour.usedPercent).toBe(15);


### PR DESCRIPTION
Closes #10

The rollout fallback previously set `observedAt = fetchedAt`, so stale data rolled forward by the service could misleadingly show "Updated just now".

Now `observedAt` is the latest rate_limits event's timestamp (when the data was actually generated), while `fetchedAt` remains the read time. The service's stale path already preserves the prior `observedAt` via object spread, so stale cards now honestly report their age.

- App Server path (live read): keeps `observedAt = fetchedAt` (correct — data is current).
- Rollout fallback: `observedAt` = latest event time.
- GLM/Kimi: no server-side observation timestamp in response, so `fetchedAt` stands, but stale cards no longer mislead because the service preserves the old `observedAt`.

## Test
Asserts `observedAt` equals the event time, not `FIXED_NOW`. typecheck/lint/73 tests pass.