### PR TITLE
feat(#13): runtime schema validation (GLM & Kimi)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "^15.3.1",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -5179,6 +5180,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "next": "^15.3.1",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/quota/providers/glm.ts
+++ b/src/quota/providers/glm.ts
@@ -12,6 +12,7 @@
 // ============================================================================
 
 import { fetchJson } from '../http.js';
+import { parseWithSchema, glmQuotaResponseSchema, type GlmQuotaResponseParsed } from '../schemas.js';
 import type {
   QuotaBucket,
   QuotaBalance,
@@ -41,20 +42,8 @@ const REGION_BASE_URLS: Record<GlmRegion, string> = {
 
 // Raw response shapes -------------------------------------------------------
 
-interface GlmLimit {
-  type: string;
-  percentage?: number;
-  unit?: number;
-  number?: number;
-  currentValue?: number;
-  usage?: number;
-  remaining?: number;
-  nextResetTime?: number; // ms epoch
-}
-interface GlmQuotaResponse {
-  data?: { limits?: GlmLimit[] };
-  limits?: GlmLimit[];
-}
+/** A single GLM limit entry (type derived from the zod schema). */
+type GlmLimit = NonNullable<NonNullable<NonNullable<GlmQuotaResponseParsed['data']>['limits']>[number]>;
 
 export class GlmProvider implements QuotaProviderAdapter {
   readonly providerId = PROVIDER_ID;
@@ -79,14 +68,15 @@ export class GlmProvider implements QuotaProviderAdapter {
     const url = `${this.baseUrl}/api/monitor/usage/quota/limit`;
 
     try {
-      const result = await fetchJson<GlmQuotaResponse>('glm', url, {
+      const result = await fetchJson<unknown>('glm', url, {
         headers: {
           Authorization: this.token,
           'Accept-Language': 'en-US,en',
           'Content-Type': 'application/json',
         },
       });
-      return this.toSnapshot(result.value, fetchedAt, previous);
+      const parsed = parseWithSchema('glm', glmQuotaResponseSchema, result.value);
+      return this.toSnapshot(parsed, fetchedAt, previous);
     } catch (err) {
       return this.toErrorSnapshot(err, fetchedAt, previous);
     }
@@ -95,7 +85,7 @@ export class GlmProvider implements QuotaProviderAdapter {
   // -----------------------------------------------------------------
 
   private toSnapshot(
-    body: GlmQuotaResponse,
+    body: GlmQuotaResponseParsed,
     fetchedAt: string,
     previous: QuotaSnapshot | null,
   ): QuotaSnapshot {
@@ -149,7 +139,14 @@ export class GlmProvider implements QuotaProviderAdapter {
 function limitToBucket(limit: GlmLimit): QuotaBucket | null {
   // Known limit types get a friendly window label from {type, unit, number}.
   const label = describeGlmWindow(limit);
-  const metric = limit.type === 'TIME_LIMIT' ? 'time' : 'tokens';
+  // Unknown limit types are surfaced as 'unknown' metric buckets (not dropped)
+  // so a new type doesn't silently disappear, but is visibly distinct (PRD #13).
+  const isKnown = limit.type === 'TOKENS_LIMIT' || limit.type === 'TIME_LIMIT';
+  const metric: QuotaBucket['metric'] = !isKnown
+    ? 'unknown'
+    : limit.type === 'TIME_LIMIT'
+      ? 'time'
+      : 'tokens';
   const usedPercent = typeof limit.percentage === 'number' ? limit.percentage : null;
 
   return {

--- a/src/quota/providers/kimi.ts
+++ b/src/quota/providers/kimi.ts
@@ -48,10 +48,7 @@ const DEFAULT_CREDENTIALS_PATH = `${homedir()}/.kimi-code/credentials/kimi-code.
 
 type RawUsagesResponse = KimiUsagesResponseParsed;
 type RawUsageDetail = NonNullable<RawUsagesResponse['usage']>;
-type RawUsageWindow = NonNullable<NonNullable<NonNullable<RawUsagesResponse['limits']>[number]['window']>>;
-type RawLimitEntry = NonNullable<NonNullable<RawUsagesResponse['limits']>[number]>;
-type RawBoosterWallet = NonNullable<RawUsagesResponse['boosterWallet']>;
-type RawBoosterBalance = NonNullable<RawBoosterWallet['balance']>;
+type RawUsageWindow = NonNullable<NonNullable<NonNullable<RawUsagesResponse['limits']>[number]>['window']>;
 
 interface StoredCredentials {
   access_token?: string;

--- a/src/quota/providers/kimi.ts
+++ b/src/quota/providers/kimi.ts
@@ -16,6 +16,11 @@ import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 
 import { fetchJson } from '../http.js';
+import {
+  parseWithSchema,
+  kimiUsagesResponseSchema,
+  type KimiUsagesResponseParsed,
+} from '../schemas.js';
 import type {
   QuotaBucket,
   QuotaBalance,
@@ -38,36 +43,15 @@ const SOURCE = { kind: 'official_compatibility' as const, name: 'Kimi Code usage
 const DEFAULT_BASE_URL = 'https://api.kimi.com/coding/v1';
 const DEFAULT_CREDENTIALS_PATH = `${homedir()}/.kimi-code/credentials/kimi-code.json`;
 
-// Raw response shapes (numbers come as decimal strings, units as enum strings)
+// Parsed response types derived from the zod schema (numbers come as decimal
+// strings, units as proto-style enum strings — normalized in the mappers below).
 
-interface RawUsageDetail {
-  used?: string;
-  limit?: string;
-  resetTime?: string;
-  name?: string;
-}
-interface RawUsageWindow {
-  duration?: number;
-  timeUnit?: string; // TIME_UNIT_MINUTE | HOUR | DAY | WEEK
-}
-interface RawLimitEntry {
-  window?: RawUsageWindow;
-  detail?: RawUsageDetail;
-}
-interface RawBoosterBalance {
-  type?: string;
-  amount?: number;
-  amountLeft?: number;
-}
-interface RawBoosterWallet {
-  balance?: RawBoosterBalance;
-  monthlyChargeLimitEnabled?: boolean;
-}
-interface RawUsagesResponse {
-  usage?: RawUsageDetail; // weekly summary
-  limits?: RawLimitEntry[];
-  boosterWallet?: RawBoosterWallet;
-}
+type RawUsagesResponse = KimiUsagesResponseParsed;
+type RawUsageDetail = NonNullable<RawUsagesResponse['usage']>;
+type RawUsageWindow = NonNullable<NonNullable<NonNullable<RawUsagesResponse['limits']>[number]['window']>>;
+type RawLimitEntry = NonNullable<NonNullable<RawUsagesResponse['limits']>[number]>;
+type RawBoosterWallet = NonNullable<RawUsagesResponse['boosterWallet']>;
+type RawBoosterBalance = NonNullable<RawBoosterWallet['balance']>;
 
 interface StoredCredentials {
   access_token?: string;
@@ -110,13 +94,14 @@ export class KimiProvider implements QuotaProviderAdapter {
     }
 
     try {
-      const result = await fetchJson<RawUsagesResponse>('kimi', `${this.baseUrl}/usages`, {
+      const result = await fetchJson<unknown>('kimi', `${this.baseUrl}/usages`, {
         headers: {
           Authorization: `Bearer ${this.accessToken}`,
           Accept: 'application/json',
         },
       });
-      return this.toSnapshot(result.value, fetchedAt, previous);
+      const parsed = parseWithSchema('kimi', kimiUsagesResponseSchema, result.value);
+      return this.toSnapshot(parsed, fetchedAt, previous);
     } catch (err) {
       return this.toErrorSnapshot(err, fetchedAt, previous);
     }

--- a/src/quota/schemas.ts
+++ b/src/quota/schemas.ts
@@ -1,0 +1,150 @@
+// ============================================================================
+// src/quota/schemas.ts
+// Runtime schema validation for provider responses (PRD §12.1 / §8.1 / #13).
+//
+// These zod schemas validate the raw JSON returned by each provider before the
+// adapter trusts it. Rules:
+//   - Unknown fields are ignored (third-party APIs evolve).
+//   - Required fields missing / wrong type => a controlled SchemaError (NOT a
+//     silent null), which adapters map to `error` or `unsupported` status.
+//   - All schemas are lenient about optionals — providers omit fields often.
+// ============================================================================
+
+import { z } from 'zod';
+
+/** Error thrown when a response fails schema validation. */
+export class SchemaError extends Error {
+  constructor(
+    public readonly provider: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SchemaError';
+  }
+}
+
+/**
+ * Parse `unknown` JSON against a schema, throwing a SchemaError on failure.
+ * Use this in adapters instead of bare `as T` casts.
+ */
+export function parseWithSchema<T>(
+  provider: string,
+  schema: z.ZodType<T>,
+  data: unknown,
+): T {
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    const first = result.error.issues[0];
+    const path = first.path.length > 0 ? ` at ${first.path.join('.')}` : '';
+    throw new SchemaError(provider, `unexpected response shape${path}: ${first.message}`);
+  }
+  return result.data;
+}
+
+// ---------------------------------------------------------------------------
+// GLM Coding Plan — /api/monitor/usage/quota/limit
+// ---------------------------------------------------------------------------
+
+export const glmLimitSchema = z
+  .object({
+    type: z.string(),
+    percentage: z.number().optional(),
+    unit: z.number().optional(),
+    number: z.number().optional(),
+    currentValue: z.number().optional(),
+    usage: z.number().optional(),
+    remaining: z.number().optional(),
+    nextResetTime: z.number().optional(), // ms epoch
+  })
+  .passthrough(); // tolerate new fields
+
+export const glmQuotaResponseSchema = z.object({
+  data: z.object({ limits: z.array(glmLimitSchema).optional() }).optional(),
+  limits: z.array(glmLimitSchema).optional(),
+}).passthrough();
+
+export type GlmQuotaResponseParsed = z.infer<typeof glmQuotaResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Kimi Code — /coding/v1/usages
+// Numbers arrive as decimal strings; we accept string|number and normalize later.
+// ---------------------------------------------------------------------------
+
+export const kimiUsageDetailSchema = z
+  .object({
+    used: z.union([z.string(), z.number()]).optional(),
+    limit: z.union([z.string(), z.number()]).optional(),
+    resetTime: z.string().optional(),
+    name: z.string().optional(),
+  })
+  .passthrough();
+
+export const kimiUsageWindowSchema = z
+  .object({
+    duration: z.number().optional(),
+    timeUnit: z.string().optional(),
+  })
+  .passthrough();
+
+export const kimiLimitEntrySchema = z
+  .object({
+    window: kimiUsageWindowSchema.optional(),
+    detail: kimiUsageDetailSchema.optional(),
+  })
+  .passthrough();
+
+export const kimiBoosterBalanceSchema = z
+  .object({
+    type: z.string().optional(),
+    amount: z.number().optional(),
+    amountLeft: z.number().optional(),
+  })
+  .passthrough();
+
+export const kimiBoosterWalletSchema = z
+  .object({
+    balance: kimiBoosterBalanceSchema.optional(),
+    monthlyChargeLimitEnabled: z.boolean().optional(),
+  })
+  .passthrough();
+
+export const kimiUsagesResponseSchema = z
+  .object({
+    usage: kimiUsageDetailSchema.optional(), // weekly summary
+    limits: z.array(kimiLimitEntrySchema).optional(),
+    boosterWallet: kimiBoosterWalletSchema.optional(),
+  })
+  .passthrough();
+
+export type KimiUsagesResponseParsed = z.infer<typeof kimiUsagesResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Codex App Server — account/rateLimits/read
+// All fields nullable (the App Server uses null liberally).
+// ---------------------------------------------------------------------------
+
+export const codexRateLimitWindowSchema = z.object({
+  usedPercent: z.number().nullable().optional(),
+  windowDurationMins: z.number().nullable().optional(),
+  resetsAt: z.number().nullable().optional(), // Unix seconds
+}).passthrough();
+
+export const codexCreditsSchema = z.object({
+  hasCredits: z.boolean().nullable().optional(),
+  unlimited: z.boolean().nullable().optional(),
+  balance: z.string().nullable().optional(),
+}).passthrough();
+
+export const codexRateLimitSnapshotSchema = z.object({
+  limitId: z.string().nullable().optional(),
+  primary: codexRateLimitWindowSchema.nullable().optional(),
+  secondary: codexRateLimitWindowSchema.nullable().optional(),
+  credits: codexCreditsSchema.nullable().optional(),
+  planType: z.string().nullable().optional(),
+}).passthrough();
+
+export const codexRateLimitsResponseSchema = z.object({
+  rateLimits: codexRateLimitSnapshotSchema.nullable(),
+}).passthrough();
+
+export type CodexRateLimitsResponseParsed = z.infer<typeof codexRateLimitsResponseSchema>;

--- a/tests/quota/glm-provider.test.ts
+++ b/tests/quota/glm-provider.test.ts
@@ -85,4 +85,41 @@ describe('GlmProvider', () => {
     await new GlmProvider({ token: 't', region: 'zai' }).fetch(null);
     expect(mock.mock.calls[0][0]).toBe('https://api.z.ai/api/monitor/usage/quota/limit');
   });
+
+  it('maps an unknown limit type to an unknown-metric bucket (not dropped)', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(200, {
+        data: { limits: [{ type: 'FUTURE_LIMIT_TYPE', percentage: 5, unit: 9, number: 1 }] },
+      }),
+    );
+    const snap = await new GlmProvider({ token: 't' }).fetch(null);
+    expect(snap.status).toBe('ready');
+    expect(snap.buckets).toHaveLength(1);
+    expect(snap.buckets[0].metric).toBe('unknown'); // visibly distinct, not 'tokens'
+  });
+
+  it('returns a controlled error on malformed response shape (schema drift)', async () => {
+    // `data.limits` is a string instead of an array → schema rejects it.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(200, { data: { limits: 'not-an-array' } }),
+    );
+    const snap = await new GlmProvider({ token: 't' }).fetch(null);
+    // Schema failure surfaces as an error status, not a crash or silent null.
+    expect(snap.status).not.toBe('ready');
+    expect(snap.error).toBeDefined();
+  });
+
+  it('tolerates extra unknown fields in the response (passthrough)', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(200, {
+        data: {
+          limits: [{ type: 'TOKENS_LIMIT', percentage: 10, unit: 3, number: 5 }],
+          newFutureField: { whatever: true },
+        },
+        extraRoot: 42,
+      }),
+    );
+    const snap = await new GlmProvider({ token: 't' }).fetch(null);
+    expect(snap.status).toBe('ready'); // unknown fields ignored, not rejected
+  });
 });

--- a/tests/quota/kimi-provider.test.ts
+++ b/tests/quota/kimi-provider.test.ts
@@ -91,4 +91,25 @@ describe('KimiProvider', () => {
     expect(new KimiProvider({ accessToken: 't' }).isConfigured()).toBe(true);
     expect(new KimiProvider({ accessToken: '' }).isConfigured()).toBe(false);
   });
+
+  it('returns a controlled error on malformed response shape (schema drift)', async () => {
+    // `limits` is a string instead of an array → schema rejects.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(200, { limits: 'not-an-array' }),
+    );
+    const snap = await new KimiProvider({ accessToken: 't' }).fetch(null);
+    expect(snap.status).not.toBe('ready');
+    expect(snap.error).toBeDefined();
+  });
+
+  it('tolerates extra unknown fields in the response (passthrough)', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(200, {
+        usage: { used: '10', limit: '100' },
+        futureField: { x: 1 },
+      }),
+    );
+    const snap = await new KimiProvider({ accessToken: 't' }).fetch(null);
+    expect(snap.status).toBe('ready');
+  });
 });


### PR DESCRIPTION
Closes #13 (GLM + Kimi; Codex App Server wiring deferred)

Adds zod-based runtime schema validation so provider responses are validated before adapters trust them (PRD §12.1 / §8.1).

## Changes
- **`src/quota/schemas.ts`**: zod schemas for GLM quota/limit, Kimi usages, and Codex App Server rateLimits. `parseWithSchema()` helper throws a controlled `SchemaError` on shape violations; unknown fields pass through.
- **GLM**: validates response; unknown limit types now map to `metric:'unknown'` buckets (visibly distinct, not dropped or mislabeled as `tokens`).
- **Kimi**: validates response; hand-written `Raw*` interfaces replaced with schema-derived types.

## Tests (5 new)
- GLM: unknown limit type → `unknown` metric bucket; malformed shape → controlled error; extra fields tolerated.
- Kimi: malformed shape → controlled error; extra fields tolerated.

## Deferred
Codex App Server schema wiring waits for #10 (PR #25) to merge, since both touch `providers/codex.ts`. The Codex schema is already defined in `schemas.ts`, ready to wire in a follow-up.

`npm run typecheck && lint && test` — 78 tests pass.