### PR TITLE
fix(#14): Codex capability detection, sandboxed subprocess, error redaction

### DIFF
--- a/src/quota/providers/codex-app-server.ts
+++ b/src/quota/providers/codex-app-server.ts
@@ -15,6 +15,8 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { homedir } from 'node:os';
 
+import { redact } from '../http.js';
+
 /** A response or notification received from the server. */
 interface JsonRpcMessage {
   id?: number;
@@ -54,6 +56,8 @@ export class CodexAppServerClient {
   private buffer = '';
   private nextId = 0;
   private initialized = false;
+  /** The initialize result, carrying userAgent/version (issue #14). */
+  private serverInfo: { userAgent?: string } | null = null;
   private readonly pending = new Map<
     number,
     { resolve: (value: unknown) => void; reject: (err: Error) => void }
@@ -76,24 +80,35 @@ export class CodexAppServerClient {
     this.proc = spawn(
       this.binaryPath,
       ['app-server', '--listen', 'stdio://'],
-      { env: { ...process.env, CODEX_HOME: this.codexHome }, stdio: ['pipe', 'pipe', 'pipe'] },
-    );
+      {
+        // Security (issue #14): do NOT inherit the full process.env — it may
+        // contain GLM/Kimi tokens. Only pass what the App Server needs.
+        env: buildSandboxEnv(this.codexHome),
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    ) as ChildProcessWithoutNullStreams;
 
     this.proc.stdout.setEncoding('utf8');
     this.proc.stdout.on('data', (chunk: string) => this.onData(chunk));
     this.proc.on('error', (err) => this.failAll(err));
 
-    // Perform the mandatory initialize request.
-    await this.request(
+    // Perform the mandatory initialize request, and retain the server's
+    // reported userAgent for capability detection / source.version (#14).
+    this.serverInfo = (await this.request(
       'initialize',
       {
         clientInfo: { name: 'usage-bar', title: 'Usage Bar', version: '0.1.0' },
       },
       this.initTimeoutMs,
-    );
+    )) as { userAgent?: string } | null;
     // Then the initialized notification (no id, no response expected).
     this.notify('initialized');
     this.initialized = true;
+  }
+
+  /** The server's userAgent from the initialize handshake (e.g. "codex 0.x.y"). */
+  getServerInfo(): { userAgent?: string } | null {
+    return this.serverInfo;
   }
 
   /** Send a method call and await its result. */
@@ -179,7 +194,9 @@ export class CodexAppServerClient {
     if (msg.id !== undefined && this.pending.has(msg.id)) {
       const handler = this.pending.get(msg.id)!;
       if (msg.error) {
-        handler.reject(new Error(`codex app-server error ${msg.error.code}: ${msg.error.message}`));
+        // Redact anything token-like from the server's error text (issue #14).
+        const safeMsg = redact(String(msg.error.message));
+        handler.reject(new Error(`codex app-server error ${msg.error.code}: ${safeMsg}`));
       } else {
         handler.resolve(msg.result);
       }
@@ -196,8 +213,25 @@ export class CodexAppServerClient {
 }
 
 // ---------------------------------------------------------------------------
-// Binary resolution
+// Binary resolution & process sandboxing
 // ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal environment for the spawned App Server process — WITHOUT
+ * inheriting the full process.env (which may carry GLM/Kimi tokens, issue #14).
+ * We pass through only what the binary needs to run and locate its home/config.
+ */
+function buildSandboxEnv(codexHome: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    NODE_ENV: process.env.NODE_ENV ?? 'production',
+    CODEX_HOME: codexHome,
+    PATH: process.env.PATH ?? '',
+    HOME: process.env.HOME ?? '',
+    LANG: process.env.LANG ?? 'en_US.UTF-8',
+  };
+  if (process.env.USER) env.USER = process.env.USER;
+  return env;
+}
 
 /**
  * Locate the codex binary. Checks PATH first, then the known macOS app bundle

--- a/src/quota/providers/codex.ts
+++ b/src/quota/providers/codex.ts
@@ -22,58 +22,45 @@ import type {
   QuotaSnapshot,
   QuotaBalance,
 } from '../contract.js';
+import {
+  parseWithSchema,
+  codexRateLimitsResponseSchema,
+  type CodexRateLimitsResponseParsed,
+} from '../schemas.js';
 import { CodexAppServerClient } from './codex-app-server.js';
 
 // ---------------------------------------------------------------------------
-// Raw App Server response shapes (camelCase on the wire)
+// Response types derived from the zod schema
 // ---------------------------------------------------------------------------
 
-interface RateLimitWindow {
-  usedPercent: number | null;
-  windowDurationMins: number | null;
-  resetsAt: number | null; // Unix seconds
-}
-interface CreditsSnapshot {
-  hasCredits: boolean | null;
-  unlimited: boolean | null;
-  balance: string | null;
-}
-interface SpendControlLimit {
-  limit: string;
-  used: string;
-  remainingPercent: number | null;
-  resetsAt: number | null;
-}
-interface RateLimitSnapshot {
-  limitId: string | null;
-  primary: RateLimitWindow | null;
-  secondary: RateLimitWindow | null;
-  credits: CreditsSnapshot | null;
-  individualLimit: SpendControlLimit | null;
-  planType: string | null;
-}
-interface GetAccountRateLimitsResponse {
-  rateLimits: RateLimitSnapshot | null;
-}
+type RateLimitsResponse = CodexRateLimitsResponseParsed;
+type RateLimitSnapshot = NonNullable<RateLimitsResponse['rateLimits']>;
+type RateLimitWindow = NonNullable<RateLimitSnapshot['primary']>;
 
 interface AppServerConfig {
   /** Override CODEX_HOME (defaults to ~/.codex). */
   codexHome?: string;
-  /** Inject a client (testing). */
-  client?: Pick<CodexAppServerClient, 'connect' | 'call' | 'done'>;
+  /** Inject a client (testing). Must expose getServerInfo for capability detection. */
+  client?: Pick<CodexAppServerClient, 'connect' | 'call' | 'done' | 'getServerInfo'>;
 }
 
 const PROVIDER_ID = 'codex_chatgpt' as const;
 const DISPLAY_NAME = 'Codex';
-const APP_SERVER_SOURCE = { kind: 'official_protocol' as const, name: 'Codex App Server', version: null, isFallback: false };
-const ROLLOUT_SOURCE = { kind: 'local_estimate' as const, name: 'Codex rollout files', version: null, isFallback: true };
+interface SourceDescriptor {
+  kind: 'official_protocol' | 'local_estimate' | 'official_compatibility';
+  name: string;
+  version: string | null;
+  isFallback: boolean;
+}
+const APP_SERVER_SOURCE: SourceDescriptor = { kind: 'official_protocol', name: 'Codex App Server', version: null, isFallback: false };
+const ROLLOUT_SOURCE: SourceDescriptor = { kind: 'local_estimate', name: 'Codex rollout files', version: null, isFallback: true };
 
 export class CodexProvider implements QuotaProviderAdapter {
   readonly providerId = PROVIDER_ID;
   readonly displayName = DISPLAY_NAME;
 
   private readonly codexHome: string;
-  private readonly clientFactory: () => Pick<CodexAppServerClient, 'connect' | 'call' | 'done'>;
+  private readonly clientFactory: () => Pick<CodexAppServerClient, 'connect' | 'call' | 'done' | 'getServerInfo'>;
 
   constructor(config: AppServerConfig = {}) {
     this.codexHome = config.codexHome ?? `${homedir()}/.codex`;
@@ -95,16 +82,23 @@ export class CodexProvider implements QuotaProviderAdapter {
     const client = this.clientFactory();
     try {
       await client.connect();
-      const result = await client.call<GetAccountRateLimitsResponse>('account/rateLimits/read');
-      const snapshot = RateLimitsToSnapshot(result, fetchedAt, previous);
-      // usage data is fetched separately by the usage module; here we only
-      // surface quota. Mark observedAt as now since the App Server read is live.
-      return snapshot;
-    } catch {
-      // Fall through to rollout estimate.
+
+      // Capability detection: read the server's reported version (issue #14).
+      const serverInfo = client.getServerInfo?.() ?? null;
+      const version = serverInfo?.userAgent ?? null;
+
+      const raw = await client.call<unknown>('account/rateLimits/read');
+      // Runtime schema validation (issue #13, Codex part).
+      const result = parseWithSchema('codex', codexRateLimitsResponseSchema, raw);
+      return rateLimitsToSnapshot(result, fetchedAt, previous, version);
+    } catch (err) {
+      // Capability explicitly unsupported (method not found / low version) →
+      // surface as `unsupported`, NOT a silent fallback (issue #14).
+      if (isUnsupportedMethod(err)) {
+        return unsupportedSnapshot(fetchedAt, previous);
+      }
+      // Otherwise transient (process missing, timeout, network) → rollout fallback.
     } finally {
-      // `done` may not exist on an injected mock that threw before assignment;
-      // guard via optional chaining. Real clients always have it.
       (client as CodexAppServerClient).done?.();
     }
 
@@ -117,14 +111,15 @@ export class CodexProvider implements QuotaProviderAdapter {
 // App Server response → QuotaSnapshot
 // ---------------------------------------------------------------------------
 
-function RateLimitsToSnapshot(
-  result: GetAccountRateLimitsResponse,
+function rateLimitsToSnapshot(
+  result: RateLimitsResponse,
   fetchedAt: string,
   previous: QuotaSnapshot | null,
+  version: string | null,
 ): QuotaSnapshot {
   const limits = result.rateLimits;
   if (!limits) {
-    return emptySnapshot(fetchedAt, APP_SERVER_SOURCE, previous, {
+    return emptySnapshot(fetchedAt, withVersion(APP_SERVER_SOURCE, version), previous, {
       code: 'empty_rate_limits',
       safeMessage: 'App Server returned no rate limits.',
       retryable: true,
@@ -155,16 +150,40 @@ function RateLimitsToSnapshot(
     status: 'ready',
     fetchedAt,
     observedAt: fetchedAt,
-    source: APP_SERVER_SOURCE,
+    source: withVersion(APP_SERVER_SOURCE, version),
     plan: { name: limits.planType ?? null, accountLabel: null },
     buckets,
     balances: balances.length > 0 ? balances : undefined,
   };
 }
 
+/** Attach the detected server version to a source descriptor. */
+function withVersion(base: SourceDescriptor, version: string | null): SourceDescriptor {
+  return { ...base, version };
+}
+
+/** True if the error means the App Server explicitly lacks a method (unsupported). */
+function isUnsupportedMethod(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message.toLowerCase();
+  // JSON-RPC -32601 method not found, or a "not supported" hint.
+  return msg.includes('-32601') || msg.includes('method not found') || msg.includes('not supported');
+}
+
+/** Snapshot for an explicitly unsupported capability (NOT a silent fallback). */
+function unsupportedSnapshot(fetchedAt: string, previous: QuotaSnapshot | null): QuotaSnapshot {
+  return emptySnapshot(fetchedAt, APP_SERVER_SOURCE, previous, {
+    code: 'unsupported_capability',
+    safeMessage: 'This Codex version does not support the required App Server methods.',
+    retryable: false,
+  }, 'unsupported');
+}
+
 function windowToBucket(id: string, w: RateLimitWindow): QuotaBucket {
   const label = describeWindow(w.windowDurationMins);
-  const usedPercent = w.usedPercent;
+  const usedPercent = w.usedPercent ?? null;
+  const windowMins = w.windowDurationMins ?? null;
+  const resetsAt = w.resetsAt ?? null;
   return {
     id,
     label,
@@ -174,12 +193,12 @@ function windowToBucket(id: string, w: RateLimitWindow): QuotaBucket {
     limit: null,
     remaining: usedPercent != null ? 100 - usedPercent : null,
     usedPercent,
-    windowSeconds: w.windowDurationMins != null ? w.windowDurationMins * 60 : null,
-    resetsAt: w.resetsAt != null ? new Date(w.resetsAt * 1000).toISOString() : null,
+    windowSeconds: windowMins != null ? windowMins * 60 : null,
+    resetsAt: resetsAt != null ? new Date(resetsAt * 1000).toISOString() : null,
   };
 }
 
-function describeWindow(mins: number | null): string {
+function describeWindow(mins: number | null | undefined): string {
   if (mins == null) return 'quota';
   if (mins === 300) return '5-hour';
   if (mins === 10080) return 'weekly';


### PR DESCRIPTION
Closes #14 (capability detection + security; `account/usage/read` tracked separately)

## Changes
- **Capability detection**: the App Server `initialize` result is now retained; `source.version` carries the real `userAgent` (verified: `codex 0.146.0-alpha.9.2 ...`), enabling version-based capability decisions.
- **Unsupported vs transient**: JSON-RPC `-32601` (method not found) → explicit `unsupported` status, NOT a silent rollout fallback. Only transient failures (process missing, timeout) fall back to Local Estimate.
- **Subprocess security**: spawned App Server no longer inherits full `process.env` (which carried GLM/Kimi tokens). `buildSandboxEnv()` passes only PATH/HOME/LANG/USER/NODE_ENV/CODEX_HOME.
- **Error redaction**: App Server error text passes through `redact()` before throwing.
- **Codex schema wiring**: rateLimits response validated via zod (the Codex half of #13, previously deferred).

## Verification
- Real App Server smoke: `source.version` populated, status `ready`, official_protocol.
- typecheck/lint/80 tests pass.

## Note
`account/usage/read` (Codex Activity via official data instead of rollout) is a larger change and will be a separate PR.