### PR TITLE
fix(#18,#19): CI build step + honest coverage config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   test:
-    name: Lint, typecheck, test, and coverage
+    name: Lint, typecheck, build, test, and coverage
     runs-on: ubuntu-latest
 
     steps:
@@ -32,6 +32,9 @@ jobs:
 
       - name: Typecheck
         run: npm run typecheck
+
+      - name: Build
+        run: npm run build
 
       - name: Test
         run: npm test

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,12 +7,17 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'lcov', 'json-summary'],
       reportsDirectory: 'coverage',
-      include: ['src/security/**/*.ts', 'src/workers/**/*.ts'],
+      // Cover the actual product paths (PRD §13.2), not the disconnected
+      // security/workers modules that produced a misleading 100%.
+      include: ['src/quota/**/*.ts', 'src/app/api/**/*.ts'],
+      // TODO(#20): raise these to PRD targets (statements ≥ 85%, branches ≥ 80%)
+      // once the remaining provider error-branch and route-contract tests land.
+      // Set to current measured values so CI stays green without gaming.
       thresholds: {
-        statements: 100,
-        branches: 100,
-        functions: 100,
-        lines: 100,
+        statements: 66,
+        branches: 57,
+        functions: 63,
+        lines: 69,
       },
     },
   },


### PR DESCRIPTION
Closes #18, Closes #19

## #19 — CI build step
CI now runs `npm run build` between typecheck and test (PRD §13.2 requires lint/typecheck/test/build on every PR).

## #18 — Honest coverage config
- `include` switched from the disconnected `security`/`workers` modules (which produced a misleading 100%) to the actual product paths (`src/quota/**`, `src/app/api/**`).
- Thresholds set to current measured values (66/57/63/69) with a TODO to raise to PRD targets (statements ≥ 85%, branches ≥ 80%) once #20's provider error-branch and route-contract tests land.

## Verification
`npm run coverage` passes the new thresholds. typecheck/lint/test/build all green locally.