### PR TITLE
fix(#16): honor Retry-After in back-off; only cache usable results

### DIFF
--- a/src/quota/http.ts
+++ b/src/quota/http.ts
@@ -38,6 +38,8 @@ export async function fetchJson<T>(
   const baseDelayMs = options.baseDelayMs ?? 500;
 
   let lastError: Error | null = null;
+  /** Server-advised delay from a Retry-After header, consumed by the back-off. */
+  let pendingRetryAfterMs: number | null = null;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
@@ -61,11 +63,16 @@ export async function fetchJson<T>(
       }
 
       const body = await res.text().catch(() => '');
-      const error = classifyError(providerLabel, res.status, redact(body), parseRetryAfter(res));
+      const retryAfterMs = parseRetryAfter(res);
+      const error = classifyError(providerLabel, res.status, redact(body), retryAfterMs);
 
       // Non-retryable: stop immediately.
       if (!error.isRetryable) {
         throw error;
+      }
+      // Stash Retry-After so the back-off below honors the server's hint.
+      if (retryAfterMs != null) {
+        pendingRetryAfterMs = retryAfterMs;
       }
       lastError = error;
     } catch (err) {
@@ -80,9 +87,14 @@ export async function fetchJson<T>(
       }
     }
 
-    // Back off before the next retry (with jitter).
+    // Back off before the next retry. Prefer the server's Retry-After when
+    // given (PRD §10); otherwise exponential back-off with jitter.
     if (attempt < maxRetries) {
-      const delay = baseDelayMs * 2 ** attempt + Math.random() * baseDelayMs;
+      const delay =
+        pendingRetryAfterMs != null
+          ? pendingRetryAfterMs
+          : baseDelayMs * 2 ** attempt + Math.random() * baseDelayMs;
+      pendingRetryAfterMs = null; // consume, don't persist across attempts
       await sleep(delay);
     }
   }

--- a/src/quota/service.ts
+++ b/src/quota/service.ts
@@ -121,7 +121,11 @@ export class QuotaService {
         this.refreshBudgetMs,
         id,
       );
-      this.cache.set(id, { snapshot, expiresAt: Date.now() + this.cacheTtlMs });
+      // Only cache successful/usable results (PRD §10). Caching errors would
+      // suppress retries for the full TTL and keep showing a failure.
+      if (snapshot.status === 'ready' || snapshot.status === 'stale') {
+        this.cache.set(id, { snapshot, expiresAt: Date.now() + this.cacheTtlMs });
+      }
       if (snapshot.status === 'ready') {
         this.lastKnownGood.set(id, snapshot);
       }

--- a/tests/quota/service.test.ts
+++ b/tests/quota/service.test.ts
@@ -163,4 +163,35 @@ describe('QuotaService', () => {
     expect(result[1].status).toBe('unavailable'); // glm failed
     expect(result[2].status).toBe('unconfigured'); // kimi not configured
   });
+
+  it('does NOT cache failed results (so retries are not suppressed)', async () => {
+    // Adapter returns an error snapshot (not a throw).
+    const codex = makeAdapter('codex_chatgpt', {
+      configured: true,
+      snapshot: {
+        ...readySnapshot('codex_chatgpt'),
+        status: 'error',
+        buckets: [],
+        error: { code: 'x', safeMessage: 'fail', retryable: true },
+      },
+    });
+    const svc = new QuotaService({ adapters: adaptersFrom({ codex_chatgpt: codex }), cacheTtlMs: 10_000 });
+
+    await svc.readAll();
+    // A second read should call fetch again (error was not cached).
+    await svc.readAll();
+    expect(codex.fetchCalls).toBe(2);
+  });
+
+  it('caches stale results (usable degraded data)', async () => {
+    const codex = makeAdapter('codex_chatgpt', {
+      configured: true,
+      snapshot: { ...readySnapshot('codex_chatgpt'), status: 'stale' },
+    });
+    const svc = new QuotaService({ adapters: adaptersFrom({ codex_chatgpt: codex }), cacheTtlMs: 10_000 });
+
+    await svc.readAll();
+    await svc.readAll();
+    expect(codex.fetchCalls).toBe(1); // stale WAS cached
+  });
 });


### PR DESCRIPTION
Closes #16

Addresses the first two refresh/cache issues from PRD §10:

1. **Retry-After honored**: the back-off delay now prefers the server's `Retry-After` value (parsed in ms, supports both seconds and HTTP-date) when present, falling back to exponential+jitter. Previously it was parsed but discarded.
2. **Only cache usable results**: the service now caches only `ready` and `stale` snapshots. Errors are not cached, so a failed provider is retried on the next read instead of being suppressed for the full 60s TTL.

The remaining two sub-items (optional auto-refresh default 5min; render-cache-then-revalidate UX) overlap with #17 (UI) and will be done there.

## Tests (2 new)
- Error snapshot → not cached (fetch called twice on two reads).
- Stale snapshot → cached (fetch called once).

82 tests pass; typecheck/lint green.