### PR TITLE
fix(#17): UI completeness — absolute reset times, config guidance, a11y

### DIFF
--- a/src/app/_components/quota-cards.tsx
+++ b/src/app/_components/quota-cards.tsx
@@ -158,12 +158,29 @@ function ProviderCard({ snap }: { snap: QuotaSnapshot }) {
           {snap.source.isFallback ? ' · fallback' : ''}
         </span>
         {snap.plan.name && <span>· {snap.plan.name}</span>}
+        {snap.plan.accountLabel && <span>· {snap.plan.accountLabel}</span>}
       </div>
 
-      {/* Error / unconfigured message */}
+      {/* Error / unconfigured / unsupported guidance (#17-3) */}
       {snap.error && (
         <p className="mt-3 rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-700">
           {snap.error.safeMessage}
+          {snap.status === 'unconfigured' && snap.providerId === 'glm_coding_plan' && (
+            <span className="mt-1 block text-slate-500">
+              Set <code className="rounded bg-slate-100 px-1">GLM_CODING_PLAN_TOKEN</code> in .env.local.
+            </span>
+          )}
+          {snap.status === 'unconfigured' && snap.providerId === 'kimi_code' && (
+            <span className="mt-1 block text-slate-500">
+              Run <code className="rounded bg-slate-100 px-1">kimi-cli login</code>, or set{' '}
+              <code className="rounded bg-slate-100 px-1">KIMI_CODE_ACCESS_TOKEN</code>.
+            </span>
+          )}
+          {snap.status === 'unsupported' && (
+            <span className="mt-1 block text-slate-500">
+              Update Codex to the latest version to enable this data source.
+            </span>
+          )}
         </p>
       )}
 
@@ -246,7 +263,11 @@ function BucketBar({ bucket }: { bucket: QuotaBucket }) {
             ? `${formatNum(bucket.used)} / ${formatNum(bucket.limit)} ${bucket.unit ?? ''}`
             : ''}
         </span>
-        {bucket.resetsAt && <span>resets {timeUntil(bucket.resetsAt)}</span>}
+        {bucket.resetsAt && (
+          <span title={bucket.resetsAt /* ISO for debugging */}>
+            resets {formatAbsoluteTime(bucket.resetsAt)} ({timeUntil(bucket.resetsAt)})
+          </span>
+        )}
       </div>
     </div>
   );
@@ -298,4 +319,16 @@ function timeUntil(iso: string): string {
   const min = Math.floor((diff % 3_600_000) / 60_000);
   if (hr >= 1) return `in ${hr}h ${min}m`;
   return `in ${min}m`;
+}
+
+/** Local-timezone absolute time, e.g. "Aug 5, 09:38" (PRD §6.3 / #17). */
+function formatAbsoluteTime(iso: string): string {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return '—';
+  return new Date(ms).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
 }

--- a/src/app/_components/usage-overview-section.tsx
+++ b/src/app/_components/usage-overview-section.tsx
@@ -196,20 +196,30 @@ function DailyChart({ records }: { records: UsageRecord[] }) {
   return (
     <div className="rounded-3xl border border-white/70 bg-white/75 p-6 text-card-foreground shadow-[0_24px_60px_-40px_rgba(15,23,42,0.55)] backdrop-blur">
       <h3 className="text-base font-semibold tracking-tight">Daily Token Usage</h3>
-      <div className="mt-5 flex items-end justify-between gap-2" style={{ height: 160 }}>
+      <div
+        className="mt-5 flex items-end justify-between gap-2"
+        style={{ height: 160 }}
+        role="img"
+        aria-label={`Daily token usage chart. ${records
+          .map((r) => `${r.date}: ${formatTokens(r.total_tokens)}`)
+          .join(', ')}`}
+      >
         {records.map((r) => {
           const h = Math.max(4, Math.round((r.total_tokens / max) * 140));
           return (
             <div
               key={r.date}
               className="flex flex-1 flex-col items-center gap-2"
-              title={`${r.date}: ${formatTokens(r.total_tokens)}`}
+              title={`${r.date}: ${formatTokens(r.total_tokens)} tokens`}
             >
               <div
                 className="w-full rounded-t bg-gradient-to-t from-slate-400 to-slate-700 transition-all"
                 style={{ height: h }}
+                aria-hidden="true"
               />
-              <span className="text-[11px] text-slate-400">{r.date.slice(5)}</span>
+              <span className="text-[11px] text-slate-400">
+                {r.date.slice(5)}: {formatTokens(r.total_tokens)}
+              </span>
             </div>
           );
         })}


### PR DESCRIPTION
Closes #17

## Changes (all verified in browser)
1. **Reset times**: local-timezone absolute time + relative countdown, ISO in title attr. e.g. `resets Aug 5, 05:38 PM (in 124h 12m)`.
2. **plan.accountLabel**: rendered when present.
3. **Config guidance**: unconfigured GLM → "set GLM_CODING_PLAN_TOKEN"; unconfigured Kimi → "run kimi-cli login or set KIMI_CODE_ACCESS_TOKEN"; unsupported → "update Codex".
4. **Chart a11y**: container `role="img"` with aria-label; bars `aria-hidden`, date labels carry readable values (PRD §12.4).

typecheck/lint/build green. Browser-verified: Codex weekly reset shows absolute+relative; Kimi card shows actionable login guidance.