### PR TITLE
fix(#15): Kimi OAuth token refresh — root cause of token_expired

### DIFF
--- a/src/quota/providers/kimi.ts
+++ b/src/quota/providers/kimi.ts
@@ -131,20 +131,27 @@ export class KimiProvider implements QuotaProviderAdapter {
     const creds = readCredentials(this.credentialsPath);
     if (!creds.access_token && !creds.refresh_token) return '';
 
-    // Re-read each call so we pick up tokens refreshed by kimi-cli between calls.
+    // Use the stored token if it is still valid.
     if (creds.access_token && !isExpired(creds)) {
       return creds.access_token;
     }
 
-    // Token missing or expired → refresh with the refresh_token.
-    // The `?? ''` right side is unreachable here (an empty access_token with
-    // no refresh_token is caught by the guard above), kept for type safety.
-    if (!creds.refresh_token) return creds.access_token ?? /* istanbul ignore next */ '';
+    // Token expired or missing. If there's no refresh_token, fall back to the
+    // (stale) access_token — the usages request will likely 401, which maps to
+    // a safe error. The guard at line 132 guarantees access_token is set here.
+    if (!creds.refresh_token) {
+      return creds.access_token as string;
+    }
 
+    // Refresh via OAuth, then persist so kimi-cli stays in sync.
     const refreshed = await refreshOAuthToken(creds.refresh_token);
-    // Write back so the CLI and subsequent calls see the fresh token.
     writeCredentials(this.credentialsPath, { ...creds, ...refreshed });
-    return refreshed.access_token ?? /* istanbul ignore next */ '';
+    // A successful refresh must yield an access_token; treat its absence as
+    // an auth failure (thrown → caller maps to token_expired).
+    if (!refreshed.access_token) {
+      throw new Error('kimi oauth refresh returned no access_token');
+    }
+    return refreshed.access_token;
   }
 
   // -----------------------------------------------------------------

--- a/src/quota/providers/kimi.ts
+++ b/src/quota/providers/kimi.ts
@@ -12,7 +12,7 @@
 // enum strings; this adapter normalizes them to the contract's numeric fields.
 // ============================================================================
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 
 import { fetchJson } from '../http.js';
@@ -52,29 +52,51 @@ type RawUsageWindow = NonNullable<NonNullable<NonNullable<RawUsagesResponse['lim
 
 interface StoredCredentials {
   access_token?: string;
-  expires_at?: number;
+  refresh_token?: string;
+  expires_at?: number; // seconds (Kimi stores epoch-seconds)
+  expires_in?: number; // seconds (lifetime, e.g. 900)
 }
+
+/** OAuth refresh endpoint + client id (from kimi-cli source). */
+const OAUTH_HOST = 'https://auth.kimi.com';
+const OAUTH_CLIENT_ID = '17e5f671-d194-4dfb-9706-5516cb48c098';
 
 export class KimiProvider implements QuotaProviderAdapter {
   readonly providerId = PROVIDER_ID;
   readonly displayName = DISPLAY_NAME;
 
-  private readonly accessToken: string;
+  private readonly accessTokenOverride: string | undefined;
+  private readonly credentialsPath: string;
   private readonly baseUrl: string;
 
   constructor(config: KimiProviderConfig = {}) {
-    this.accessToken = config.accessToken ?? readKimiAccessToken(config.credentialsPath);
+    this.accessTokenOverride = config.accessToken;
+    this.credentialsPath = config.credentialsPath ?? DEFAULT_CREDENTIALS_PATH;
     this.baseUrl = (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
   }
 
   isConfigured(): boolean {
-    return !!this.accessToken;
+    if (this.accessTokenOverride) return true;
+    const creds = readCredentials(this.credentialsPath);
+    return !!(creds.access_token || creds.refresh_token);
   }
 
   async fetch(previous: QuotaSnapshot | null): Promise<QuotaSnapshot> {
     const fetchedAt = new Date().toISOString();
 
-    if (!this.accessToken) {
+    // Resolve a valid access token, refreshing via OAuth if necessary (#15).
+    let token: string;
+    try {
+      token = await this.resolveAccessToken();
+    } catch {
+      return empty(fetchedAt, previous, {
+        code: 'token_expired',
+        safeMessage: 'Kimi Code token expired or revoked. Re-login via kimi-cli.',
+        retryable: false,
+      }, 'unconfigured');
+    }
+
+    if (!token) {
       return empty(fetchedAt, previous, {
         code: 'no_credentials',
         safeMessage: 'Kimi Code not logged in. Run kimi-cli login.',
@@ -82,18 +104,10 @@ export class KimiProvider implements QuotaProviderAdapter {
       }, 'unconfigured');
     }
 
-    if (isTokenExpired()) {
-      return empty(fetchedAt, previous, {
-        code: 'token_expired',
-        safeMessage: 'Kimi Code token expired. Re-login via kimi-cli.',
-        retryable: false,
-      }, 'unconfigured');
-    }
-
     try {
       const result = await fetchJson<unknown>('kimi', `${this.baseUrl}/usages`, {
         headers: {
-          Authorization: `Bearer ${this.accessToken}`,
+          Authorization: `Bearer ${token}`,
           Accept: 'application/json',
         },
       });
@@ -102,6 +116,33 @@ export class KimiProvider implements QuotaProviderAdapter {
     } catch (err) {
       return this.toErrorSnapshot(err, fetchedAt, previous);
     }
+  }
+
+  /**
+   * Resolve a valid access token. If an override is configured, use it as-is.
+   * Otherwise read the credentials file; if the stored token is expired (or
+   * near expiry), refresh it via the OAuth refresh_token grant and write the
+   * refreshed credentials back so kimi-cli and this app stay in sync (#15).
+   * Throws if no usable token can be obtained.
+   */
+  private async resolveAccessToken(): Promise<string> {
+    if (this.accessTokenOverride) return this.accessTokenOverride;
+
+    const creds = readCredentials(this.credentialsPath);
+    if (!creds.access_token && !creds.refresh_token) return '';
+
+    // Re-read each call so we pick up tokens refreshed by kimi-cli between calls.
+    if (creds.access_token && !isExpired(creds)) {
+      return creds.access_token;
+    }
+
+    // Token missing or expired → refresh with the refresh_token.
+    if (!creds.refresh_token) return creds.access_token ?? '';
+
+    const refreshed = await refreshOAuthToken(creds.refresh_token);
+    // Write back so the CLI and subsequent calls see the fresh token.
+    writeCredentials(this.credentialsPath, { ...creds, ...refreshed });
+    return refreshed.access_token ?? '';
   }
 
   // -----------------------------------------------------------------
@@ -237,20 +278,63 @@ function toNumber(value: string | number | undefined): number | null {
 // Credentials + expiry
 // ---------------------------------------------------------------------------
 
-function readKimiAccessToken(credentialsPath?: string): string {
-  const path = credentialsPath ?? DEFAULT_CREDENTIALS_PATH;
+/** Read the stored credentials file (best-effort). */
+function readCredentials(path: string): StoredCredentials {
   try {
-    const creds = JSON.parse(readFileSync(path, 'utf8')) as StoredCredentials;
-    return creds.access_token ?? '';
+    return JSON.parse(readFileSync(path, 'utf8')) as StoredCredentials;
   } catch {
-    return '';
+    return {};
   }
 }
 
-function isTokenExpired(): boolean {
-  // We can't access the stored expiry without re-reading; the 401 path handles
-  // actual expiry. For a pre-check, rely on the server's 401. Return false here.
-  return false;
+/**
+ * Is the stored token expired? Kimi stores expires_at as epoch-SECONDS, and
+ * tokens last ~15min (expires_in=900). We treat it as expired if less than
+ * 60s of life remains, to avoid a race right at the boundary.
+ */
+function isExpired(creds: StoredCredentials): boolean {
+  const expiresAtSec = creds.expires_at;
+  if (typeof expiresAtSec !== 'number') {
+    // No expiry recorded → assume expired (forces a refresh attempt, which
+    // fails safely into the 401 path if the token is actually still valid).
+    return true;
+  }
+  // expires_at is seconds; compare against now-in-seconds + 60s buffer.
+  const nowSec = Math.floor(Date.now() / 1000);
+  return expiresAtSec <= nowSec + 60;
+}
+
+/** Refresh the access token via the OAuth refresh_token grant. */
+async function refreshOAuthToken(refreshToken: string): Promise<StoredCredentials> {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: OAUTH_CLIENT_ID,
+  });
+  const res = await fetch(`${OAUTH_HOST}/api/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+  if (!res.ok) {
+    throw new Error(`kimi oauth refresh failed: HTTP ${res.status}`);
+  }
+  const data = (await res.json()) as StoredCredentials;
+  // Compute expires_at (seconds) from expires_in so isExpired works next time.
+  if (data.expires_in != null && data.expires_at == null) {
+    data.expires_at = Math.floor(Date.now() / 1000) + data.expires_in;
+  }
+  return data;
+}
+
+/** Write refreshed credentials back, preserving file permissions (#15). */
+function writeCredentials(path: string, creds: StoredCredentials): void {
+  try {
+    writeFileSync(path, JSON.stringify(creds, null, 2));
+  } catch {
+    // Non-fatal: if we can't persist, the in-memory token still works for
+    // this request; next call will refresh again.
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/quota/providers/kimi.ts
+++ b/src/quota/providers/kimi.ts
@@ -137,12 +137,14 @@ export class KimiProvider implements QuotaProviderAdapter {
     }
 
     // Token missing or expired → refresh with the refresh_token.
-    if (!creds.refresh_token) return creds.access_token ?? '';
+    // The `?? ''` right side is unreachable here (an empty access_token with
+    // no refresh_token is caught by the guard above), kept for type safety.
+    if (!creds.refresh_token) return creds.access_token ?? /* istanbul ignore next */ '';
 
     const refreshed = await refreshOAuthToken(creds.refresh_token);
     // Write back so the CLI and subsequent calls see the fresh token.
     writeCredentials(this.credentialsPath, { ...creds, ...refreshed });
-    return refreshed.access_token ?? '';
+    return refreshed.access_token ?? /* istanbul ignore next */ '';
   }
 
   // -----------------------------------------------------------------

--- a/tests/quota/kimi-provider.test.ts
+++ b/tests/quota/kimi-provider.test.ts
@@ -249,4 +249,49 @@ describe('KimiProvider token refresh', () => {
     // Only the usages call happened — no refresh.
     expect(mock.mock.calls.every((c) => !String(c[0]).includes('auth.kimi.com'))).toBe(true);
   });
+
+  it('returns unconfigured when the refresh endpoint itself errors (HTTP 500)', async () => {
+    await writeFile(
+      credsPath,
+      JSON.stringify({
+        access_token: 'old',
+        refresh_token: 'rt',
+        expires_at: Math.floor(Date.now() / 1000) - 3600,
+      }),
+    );
+    // refreshOAuthToken fetch returns 500 → throws → resolveAccessToken throws.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(500, { error: 'server' }),
+    );
+
+    const snap = await new KimiProvider({ credentialsPath: credsPath }).fetch(null);
+    expect(snap.status).toBe('unconfigured');
+    expect(snap.error?.code).toBe('token_expired');
+  });
+
+  it('still fetches successfully when writing refreshed creds fails (non-fatal)', async () => {
+    await writeFile(
+      credsPath,
+      JSON.stringify({
+        access_token: 'old',
+        refresh_token: 'rt',
+        expires_at: Math.floor(Date.now() / 1000) - 3600,
+      }),
+    );
+    // Point credentialsPath at a path whose directory vanishes after read,
+    // so the write-back fails — but the in-memory refreshed token still works.
+    const mock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    mock.mockImplementation(async (url: string) => {
+      if (String(url).includes('auth.kimi.com')) {
+        return jsonResponse(200, { access_token: 'fresh', expires_in: 900 });
+      }
+      return jsonResponse(200, { usage: { used: '2', limit: '10' } });
+    });
+
+    // Use a credentials path under a read-only-ish location to force write failure.
+    const badPath = '/dev/null/not-writable/kimi-code.json';
+    const snap = await new KimiProvider({ credentialsPath: badPath }).fetch(null);
+    // No creds readable at badPath → treated as no credentials.
+    expect(snap.status).toBe('unconfigured');
+  });
 });

--- a/tests/quota/kimi-provider.test.ts
+++ b/tests/quota/kimi-provider.test.ts
@@ -119,4 +119,32 @@ describe('KimiProvider', () => {
     const snap = await new KimiProvider({ accessToken: 't' }).fetch(null);
     expect(snap.status).toBe('ready');
   });
+
+  it('maps a 403 to error status with forbidden code', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(403, {}),
+    );
+    const snap = await new KimiProvider({ accessToken: 't' }).fetch(null);
+    expect(snap.status).toBe('error');
+    expect(snap.error?.code).toBe('forbidden');
+  });
+
+  it('maps a 404 to unsupported status', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(404, {}),
+    );
+    const snap = await new KimiProvider({ accessToken: 't' }).fetch(null);
+    expect(snap.status).toBe('unsupported');
+    expect(snap.error?.code).toBe('endpoint_not_found');
+  });
+
+  it('maps a 429 to unavailable (transient, retryable)', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(429, {}),
+    );
+    const snap = await new KimiProvider({ accessToken: 't' }).fetch(null);
+    expect(snap.status).toBe('unavailable');
+    expect(snap.error?.code).toBe('transient');
+    expect(snap.error?.retryable).toBe(true);
+  });
 });

--- a/tests/quota/kimi-provider.test.ts
+++ b/tests/quota/kimi-provider.test.ts
@@ -150,6 +150,30 @@ describe('KimiProvider', () => {
     expect(snap.error?.code).toBe('transient');
     expect(snap.error?.retryable).toBe(true);
   });
+
+  it('labels a non-hourly minute window verbatim (e.g. 90-minute)', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(200, {
+        limits: [{ window: { duration: 90, timeUnit: 'TIME_UNIT_MINUTE' }, detail: { used: '1', limit: '10' } }],
+      }),
+    );
+    const snap = await new KimiProvider({ accessToken: 't' }).fetch(null);
+    expect(snap.buckets[0].label).toBe('90-minute');
+  });
+
+  it('labels DAY and WEEK windows', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(200, {
+        limits: [
+          { window: { duration: 3, timeUnit: 'TIME_UNIT_DAY' }, detail: { used: '1', limit: '10' } },
+          { window: { duration: 2, timeUnit: 'TIME_UNIT_WEEK' }, detail: { used: '1', limit: '10' } },
+        ],
+      }),
+    );
+    const snap = await new KimiProvider({ accessToken: 't' }).fetch(null);
+    expect(snap.buckets[0].label).toBe('3-day');
+    expect(snap.buckets[1].label).toBe('2-week');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -169,6 +193,13 @@ describe('KimiProvider token refresh', () => {
   afterEach(async () => {
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
+    // Restore perms before removing (a test may have chmod'd a subdir read-only).
+    try {
+      const { chmod } = await import('node:fs/promises');
+      await chmod(join(dir, 'creds'), 0o700).catch(() => {});
+    } catch {
+      // ignore
+    }
     await rm(dir, { recursive: true, force: true });
   });
 
@@ -250,6 +281,26 @@ describe('KimiProvider token refresh', () => {
     expect(mock.mock.calls.every((c) => !String(c[0]).includes('auth.kimi.com'))).toBe(true);
   });
 
+  it('treats a token with no expires_at as expired (forces refresh)', async () => {
+    // No expires_at field → isExpired returns true → refresh is attempted.
+    await writeFile(
+      credsPath,
+      JSON.stringify({ access_token: 'maybe-stale', refresh_token: 'rt' }),
+    );
+    const mock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    mock.mockImplementation(async (url: string) => {
+      if (String(url).includes('auth.kimi.com')) {
+        return jsonResponse(200, { access_token: 'refreshed', expires_in: 900 });
+      }
+      return jsonResponse(200, { usage: { used: '3', limit: '10' } });
+    });
+
+    const snap = await new KimiProvider({ credentialsPath: credsPath }).fetch(null);
+    expect(snap.status).toBe('ready');
+    // A refresh call happened (proving isExpired returned true for missing expires_at).
+    expect(mock.mock.calls.some((c) => String(c[0]).includes('auth.kimi.com'))).toBe(true);
+  });
+
   it('returns unconfigured when the refresh endpoint itself errors (HTTP 500)', async () => {
     await writeFile(
       credsPath,
@@ -259,10 +310,14 @@ describe('KimiProvider token refresh', () => {
         expires_at: Math.floor(Date.now() / 1000) - 3600,
       }),
     );
-    // refreshOAuthToken fetch returns 500 → throws → resolveAccessToken throws.
-    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
-      jsonResponse(500, { error: 'server' }),
-    );
+    // refreshOAuthToken fetch returns 500 → res.ok is false → throws.
+    const mock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    mock.mockImplementation(async (url: string) => {
+      if (String(url).includes('auth.kimi.com')) {
+        return jsonResponse(500, { error: 'server' });
+      }
+      return jsonResponse(200, { usage: { used: '1', limit: '10' } });
+    });
 
     const snap = await new KimiProvider({ credentialsPath: credsPath }).fetch(null);
     expect(snap.status).toBe('unconfigured');
@@ -270,16 +325,22 @@ describe('KimiProvider token refresh', () => {
   });
 
   it('still fetches successfully when writing refreshed creds fails (non-fatal)', async () => {
+    const { mkdir, chmod } = await import('node:fs/promises');
+    // creds live in a subdir; after writing creds we make the subdir read-only
+    // so the write-back fails, while the already-open read still succeeded.
+    const subDir = join(dir, 'creds');
+    await mkdir(subDir);
+    const roPath = join(subDir, 'kimi-code.json');
     await writeFile(
-      credsPath,
+      roPath,
       JSON.stringify({
         access_token: 'old',
         refresh_token: 'rt',
         expires_at: Math.floor(Date.now() / 1000) - 3600,
       }),
     );
-    // Point credentialsPath at a path whose directory vanishes after read,
-    // so the write-back fails — but the in-memory refreshed token still works.
+    await chmod(subDir, 0o500); // r-x: read ok, write denied
+
     const mock = globalThis.fetch as ReturnType<typeof vi.fn>;
     mock.mockImplementation(async (url: string) => {
       if (String(url).includes('auth.kimi.com')) {
@@ -288,10 +349,9 @@ describe('KimiProvider token refresh', () => {
       return jsonResponse(200, { usage: { used: '2', limit: '10' } });
     });
 
-    // Use a credentials path under a read-only-ish location to force write failure.
-    const badPath = '/dev/null/not-writable/kimi-code.json';
-    const snap = await new KimiProvider({ credentialsPath: badPath }).fetch(null);
-    // No creds readable at badPath → treated as no credentials.
-    expect(snap.status).toBe('unconfigured');
+    const snap = await new KimiProvider({ credentialsPath: roPath }).fetch(null);
+    // writeCredentials failed silently, but the in-memory refreshed token worked.
+    expect(snap.status).toBe('ready');
+    expect(snap.buckets[0].used).toBe(2);
   });
 });

--- a/tests/quota/kimi-provider.test.ts
+++ b/tests/quota/kimi-provider.test.ts
@@ -132,6 +132,21 @@ describe('KimiProvider', () => {
     expect(snap.error?.code).toBe('forbidden');
   });
 
+  it('falls back to stale when refresh fails but a prior ready snapshot exists', async () => {
+    let ok = true;
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      if (ok) return jsonResponse(200, { usage: { used: '1', limit: '10' } });
+      return jsonResponse(403, {});
+    });
+    const p = new KimiProvider({ accessToken: 't' });
+    const first = await p.fetch(null);
+    expect(first.status).toBe('ready');
+    ok = false;
+    const second = await p.fetch(first);
+    expect(second.status).toBe('stale');
+    expect(second.buckets.length).toBeGreaterThan(0); // kept old data
+  });
+
   it('maps a 404 to unsupported status', async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
       jsonResponse(404, {}),

--- a/tests/quota/kimi-provider.test.ts
+++ b/tests/quota/kimi-provider.test.ts
@@ -301,6 +301,23 @@ describe('KimiProvider token refresh', () => {
     expect(mock.mock.calls.some((c) => String(c[0]).includes('auth.kimi.com'))).toBe(true);
   });
 
+  it('refreshes when only a refresh_token is stored (no access_token)', async () => {
+    // Covers the `!access_token && !refresh_token` short-circuit partial: here
+    // access_token is absent but refresh_token is present, so the guard at 132
+    // does NOT return (first operand true, second false).
+    await writeFile(credsPath, JSON.stringify({ refresh_token: 'rt-only' }));
+    const mock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    mock.mockImplementation(async (url: string) => {
+      if (String(url).includes('auth.kimi.com')) {
+        return jsonResponse(200, { access_token: 'from-refresh', expires_in: 900 });
+      }
+      return jsonResponse(200, { usage: { used: '7', limit: '10' } });
+    });
+    const snap = await new KimiProvider({ credentialsPath: credsPath }).fetch(null);
+    expect(snap.status).toBe('ready');
+    expect(snap.buckets[0].used).toBe(7);
+  });
+
   it('returns unconfigured when the refresh endpoint itself errors (HTTP 500)', async () => {
     await writeFile(
       credsPath,

--- a/tests/quota/kimi-provider.test.ts
+++ b/tests/quota/kimi-provider.test.ts
@@ -324,6 +324,37 @@ describe('KimiProvider token refresh', () => {
     expect(snap.error?.code).toBe('token_expired');
   });
 
+  it('returns the stale access_token when expired but no refresh_token to renew', async () => {
+    // access_token present but expired, no refresh_token → resolveAccessToken
+    // returns the stale token via `creds.access_token ?? ''`; usages then 401.
+    await writeFile(
+      credsPath,
+      JSON.stringify({ access_token: 'stale', expires_at: 1 }),
+    );
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(401, {}),
+    );
+    const snap = await new KimiProvider({ credentialsPath: credsPath }).fetch(null);
+    expect(snap.status).toBe('unconfigured');
+  });
+
+  it('returns empty when refresh succeeds but yields no access_token', async () => {
+    // refresh returns 200 but no access_token field → refreshed.access_token ?? ''
+    await writeFile(
+      credsPath,
+      JSON.stringify({ access_token: 'old', refresh_token: 'rt', expires_at: 1 }),
+    );
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementation(async (url: string) => {
+      if (String(url).includes('auth.kimi.com')) {
+        return jsonResponse(200, { refresh_token: 'rt2', expires_in: 900 }); // no access_token
+      }
+      return jsonResponse(200, { usage: { used: '1', limit: '10' } });
+    });
+    const snap = await new KimiProvider({ credentialsPath: credsPath }).fetch(null);
+    // No usable access token → unconfigured.
+    expect(snap.status).toBe('unconfigured');
+  });
+
   it('still fetches successfully when writing refreshed creds fails (non-fatal)', async () => {
     const { mkdir, chmod } = await import('node:fs/promises');
     // creds live in a subdir; after writing creds we make the subdir read-only

--- a/tests/quota/kimi-provider.test.ts
+++ b/tests/quota/kimi-provider.test.ts
@@ -69,7 +69,11 @@ describe('KimiProvider', () => {
   });
 
   it('returns unconfigured when no access token is available', async () => {
-    const snap = await new KimiProvider({ accessToken: '' }).fetch(null);
+    // Point at a non-existent credentials file so the real one isn't read.
+    const snap = await new KimiProvider({
+      accessToken: '',
+      credentialsPath: '/nonexistent/kimi-code.json',
+    }).fetch(null);
     expect(snap.status).toBe('unconfigured');
     expect(snap.error?.code).toBe('no_credentials');
     expect(globalThis.fetch).not.toHaveBeenCalled();
@@ -89,7 +93,10 @@ describe('KimiProvider', () => {
 
   it('isConfigured reflects token presence', () => {
     expect(new KimiProvider({ accessToken: 't' }).isConfigured()).toBe(true);
-    expect(new KimiProvider({ accessToken: '' }).isConfigured()).toBe(false);
+    // No override + no readable credentials file → not configured.
+    expect(
+      new KimiProvider({ accessToken: '', credentialsPath: '/nonexistent/kimi-code.json' }).isConfigured(),
+    ).toBe(false);
   });
 
   it('returns a controlled error on malformed response shape (schema drift)', async () => {

--- a/tests/quota/kimi-provider.test.ts
+++ b/tests/quota/kimi-provider.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { KimiProvider } from '../../src/quota/providers/kimi.js';
@@ -146,5 +149,104 @@ describe('KimiProvider', () => {
     expect(snap.status).toBe('unavailable');
     expect(snap.error?.code).toBe('transient');
     expect(snap.error?.retryable).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OAuth token refresh path (issue #32)
+// ---------------------------------------------------------------------------
+
+describe('KimiProvider token refresh', () => {
+  const originalFetch = globalThis.fetch;
+  let dir: string;
+  let credsPath: string;
+
+  beforeEach(async () => {
+    globalThis.fetch = vi.fn();
+    dir = await mkdtemp(join(tmpdir(), 'kimi-creds-'));
+    credsPath = join(dir, 'kimi-code.json');
+  });
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('refreshes an expired access_token via refresh_token, then fetches usage', async () => {
+    // Stored creds: expired token (expires_at in the past) + a refresh_token.
+    await writeFile(
+      credsPath,
+      JSON.stringify({
+        access_token: 'old-expired',
+        refresh_token: 'valid-refresh',
+        expires_at: Math.floor(Date.now() / 1000) - 3600, // 1h ago
+        token_type: 'Bearer',
+        expires_in: 900,
+        scope: 'kimi-code',
+      }),
+    );
+
+    const mock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    // 1st call → OAuth refresh endpoint returns a new access_token.
+    // 2nd call → usages endpoint returns data.
+    mock.mockImplementation(async (url: string) => {
+      if (String(url).includes('auth.kimi.com')) {
+        return jsonResponse(200, {
+          access_token: 'new-refreshed',
+          refresh_token: 'rotated-refresh',
+          token_type: 'Bearer',
+          expires_in: 900,
+          scope: 'kimi-code',
+        });
+      }
+      return jsonResponse(200, { usage: { used: '5', limit: '100' } });
+    });
+
+    const snap = await new KimiProvider({ credentialsPath: credsPath }).fetch(null);
+    expect(snap.status).toBe('ready');
+    expect(snap.buckets[0].used).toBe(5);
+    // The usages request used the refreshed token, not the old one.
+    const usagesCall = mock.mock.calls.find((c) => String(c[0]).includes('/usages'));
+    expect((usagesCall![1].headers as Record<string, string>).Authorization).toBe(
+      'Bearer new-refreshed',
+    );
+  });
+
+  it('returns unconfigured when refresh fails (revoked refresh_token)', async () => {
+    await writeFile(
+      credsPath,
+      JSON.stringify({
+        access_token: 'old-expired',
+        refresh_token: 'revoked',
+        expires_at: Math.floor(Date.now() / 1000) - 3600,
+      }),
+    );
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(401, { error: 'invalid_grant' }),
+    );
+
+    const snap = await new KimiProvider({ credentialsPath: credsPath }).fetch(null);
+    expect(snap.status).toBe('unconfigured');
+    expect(snap.error?.code).toBe('token_expired');
+  });
+
+  it('uses the stored token directly when not expired (no refresh call)', async () => {
+    await writeFile(
+      credsPath,
+      JSON.stringify({
+        access_token: 'still-valid',
+        refresh_token: 'unused',
+        expires_at: Math.floor(Date.now() / 1000) + 3600, // 1h in future
+        token_type: 'Bearer',
+        expires_in: 900,
+        scope: 'kimi-code',
+      }),
+    );
+    const mock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    mock.mockResolvedValue(jsonResponse(200, { usage: { used: '1', limit: '10' } }));
+
+    await new KimiProvider({ credentialsPath: credsPath }).fetch(null);
+    // Only the usages call happened — no refresh.
+    expect(mock.mock.calls.every((c) => !String(c[0]).includes('auth.kimi.com'))).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #32 (the token_expired bug). Relates to #15 (Kimi integration).

## Root cause
The Kimi card always showed `token_expired` even though `kimi-cli` worked fine. The credentials file's `access_token` expires every **15 minutes** (`expires_in=900`); kimi-cli refreshes it via the `refresh_token` before each request, but our code read the stale file token directly — `isTokenExpired()` was a stub returning `false`, with no refresh logic at all.

## Fix
`KimiProvider.resolveAccessToken()` now:
1. reads the credentials file (`access_token` + `refresh_token` + `expires_at`);
2. if expired (or within 60s of expiry), performs the OAuth `refresh_token` grant against `auth.kimi.com` and **writes the refreshed creds back** so kimi-cli and this app stay in sync;
3. an explicit `KIMI_CODE_ACCESS_TOKEN` override bypasses refresh entirely.

`expires_at` is correctly handled as epoch-**seconds** (Kimi's format), not ms.

## Verified
- Real fetch now returns `ready`: weekly 70/100, 5-hour 4/100 (was always token_expired before).
- Credentials file integrity + permissions (600) preserved; kimi-cli unaffected.
- Tests fixed to isolate from the real credentials file.

Note: the local_bridge integration path (#15) turned out unnecessary — direct OAuth refresh works reliably and is what gives kimi-cli its robustness.

82 tests pass; typecheck/lint green.