### PR TITLE
chore: add GitHub issue templates (bug, feature, PRD task)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,67 +1,67 @@
-name: 🐛 Bug 报告
-description: 报告配额看板的错误行为或数据问题
+name: 🐛 Bug Report
+description: Report incorrect behavior or data problems in the quota dashboard
 title: "[Bug] "
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        感谢报告问题。**请勿在 issue 中粘贴任何 token、API Key 或完整账号信息**——日志请先脱敏。
+        Thanks for reporting. **Never paste tokens, API keys, or full account identifiers into an issue** — redact logs before attaching them.
 
   - type: dropdown
     id: provider
     attributes:
-      label: 受影响的 Provider
-      description: 问题发生在哪个数据路径上？
+      label: Affected provider
+      description: Which data path is the problem on?
       multiple: true
       options:
-        - Codex（codex_chatgpt）
-        - GLM Coding Plan（glm_coding_plan）
-        - Kimi Code（kimi_code）
-        - 聚合 API / 共享层
-        - UI / 前端
-        - 其他
+        - Codex (codex_chatgpt)
+        - GLM Coding Plan (glm_coding_plan)
+        - Kimi Code (kimi_code)
+        - Aggregation API / shared layer
+        - UI / frontend
+        - Other
     validations:
       required: true
 
   - type: textarea
     id: description
     attributes:
-      label: 问题描述
-      description: 发生了什么？期望行为是什么？
+      label: What happened?
+      description: Describe the actual behavior and what you expected instead.
       placeholder: |
-        实际：…
-        期望：…
+        Actual: …
+        Expected: …
     validations:
       required: true
 
   - type: textarea
     id: reproduce
     attributes:
-      label: 复现步骤
+      label: Steps to reproduce
       placeholder: |
-        1. 配置 …
-        2. 运行 npm run dev
-        3. 打开首页 / 调用 /api/v1/quota
-        4. 看到 …
+        1. Configure …
+        2. Run npm run dev
+        3. Open the dashboard / call /api/v1/quota
+        4. Observe …
     validations:
       required: true
 
   - type: textarea
     id: evidence
     attributes:
-      label: 日志 / 响应 / 截图
-      description: 相关的 API 响应、控制台输出或截图（务必脱敏）
+      label: Logs / responses / screenshots
+      description: Relevant API responses, console output, or screenshots (must be redacted)
       render: text
 
   - type: textarea
     id: environment
     attributes:
-      label: 环境信息
+      label: Environment
       placeholder: |
         - OS: macOS 15.x
         - Node: v22.x
-        - 相关 CLI 版本（codex / kimi CLI）: …
-        - 数据源：official_protocol / official_compatibility / local_estimate
+        - Relevant CLI versions (codex / kimi CLI): …
+        - Data source: official_protocol / official_compatibility / local_estimate
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 📖 产品需求文档（PRD）
+  - name: 📖 Product Requirements Document (PRD)
     url: https://github.com/gausshj/usage-bar/blob/main/docs/PRD.md
-    about: 提 issue 前请先确认与 PRD 的范围和验收标准一致
+    about: Please confirm your issue aligns with the PRD scope and acceptance criteria before filing

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,40 +1,40 @@
-name: ✨ 功能请求
-description: 提出新能力或改进建议
+name: ✨ Feature Request
+description: Propose a new capability or improvement
 title: "[Feature] "
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        先确认请求符合 `docs/PRD.md` 的范围——v1 是个人本地优先的三卡配额看板，不做团队计费、成本核算或云端同步（见 PRD §4.2 非目标）。
+        Please check the scope in `docs/PRD.md` first — v1 is a personal, local-first, three-card quota dashboard. Team billing, cost accounting, and cloud sync are explicit non-goals (PRD §4.2).
 
   - type: textarea
     id: problem
     attributes:
-      label: 要解决的问题
-      description: 你遇到的场景或痛点是什么？
-      placeholder: 当我在 … 时，我希望 …
+      label: What problem does this solve?
+      description: Describe the scenario or pain point.
+      placeholder: When I …, I want …
     validations:
       required: true
 
   - type: textarea
     id: proposal
     attributes:
-      label: 建议方案
-      description: 你期望的行为或交互
+      label: Proposed solution
+      description: The behavior or interaction you expect.
     validations:
       required: true
 
   - type: textarea
     id: alternatives
     attributes:
-      label: 考虑过的替代方案
-      description: 可选
+      label: Alternatives considered
+      description: Optional.
 
   - type: checkboxes
     id: scope-check
     attributes:
-      label: 范围确认
+      label: Scope check
       options:
-        - label: 我确认该请求不属于 PRD §4.2 列出的非目标
+        - label: I confirm this request is not one of the non-goals listed in PRD §4.2
           required: true

--- a/.github/ISSUE_TEMPLATE/prd_task.yml
+++ b/.github/ISSUE_TEMPLATE/prd_task.yml
@@ -1,30 +1,30 @@
-name: 📋 PRD 实施任务
-description: 从 PRD / 审计产生的实现任务（供维护者与 coding agent 使用）
+name: 📋 PRD Implementation Task
+description: Implementation or audit-remediation task derived from the PRD (for maintainers and coding agents)
 title: "[Task] "
 labels: ["task"]
 body:
   - type: markdown
     attributes:
       value: |
-        用于 PRD 实施、审计修复类任务。一个 issue 只装一个可独立验收的问题。
+        For PRD implementation and audit-remediation tasks. One independently verifiable problem per issue.
 
   - type: dropdown
     id: priority
     attributes:
-      label: 优先级
+      label: Priority
       options:
-        - P0 — 正确性 / 安全问题
-        - P1 — 契约与核心功能
-        - P2 — 产品化收尾
-        - P3 — 发布门槛 / 工程效率
+        - P0 — correctness / security
+        - P1 — contract & core functionality
+        - P2 — productization polish
+        - P3 — release gates / engineering hygiene
     validations:
       required: true
 
   - type: input
     id: prd-ref
     attributes:
-      label: PRD 章节
-      description: 关联的 docs/PRD.md 章节，如 §7.1 / §14.2
+      label: PRD section
+      description: Related section in docs/PRD.md, e.g. §7.1 / §14.2
       placeholder: "§x.y"
     validations:
       required: true
@@ -32,17 +32,17 @@ body:
   - type: textarea
     id: problem
     attributes:
-      label: 问题 / 背景
-      description: 现状与差距，注明文件路径和行号
-      placeholder: 文件：`src/quota/...`。目前 …，PRD 要求 …
+      label: Problem / background
+      description: Current state vs. the gap. Cite file paths and line numbers.
+      placeholder: "File: `src/quota/...`. Currently …, but the PRD requires …"
     validations:
       required: true
 
   - type: textarea
     id: tasks
     attributes:
-      label: 任务清单
-      description: 用复选框列出，完成一项勾一项
+      label: Task list
+      description: Use checkboxes; tick items off as they land.
       value: |
         - [ ] 
     validations:
@@ -51,15 +51,15 @@ body:
   - type: textarea
     id: acceptance
     attributes:
-      label: 验收标准
-      description: 如何验证完成（测试命令、预期行为）
-      placeholder: "`npm test` 通过；…"
+      label: Acceptance criteria
+      description: How completion is verified (test commands, expected behavior).
+      placeholder: "`npm test` passes; …"
     validations:
       required: true
 
   - type: input
     id: blocked-by
     attributes:
-      label: 依赖
-      description: 被哪些 issue 阻塞（#N），无则留空
+      label: Blocked by
+      description: Issues blocking this one (#N). Leave empty if none.
       placeholder: "#9, #10"


### PR DESCRIPTION
## Summary

Add `.github/ISSUE_TEMPLATE/` with issue forms, following the conventions of mainstream open-source projects (e.g. VS Code, Vite, Kubernetes):

- **bug_report.yml** — affected-provider dropdown, reproduction steps, environment fields, and a prominent warning against pasting tokens or credentials
- **feature_request.yml** — mandatory checkbox confirming the request is not a PRD §4.2 non-goal
- **prd_task.yml** — priority (P0–P3), PRD section reference, checkbox task list, acceptance criteria, and blocked-by field; matches the workflow of implementation issues #9–#22
- **config.yml** — disables blank issues and links to the PRD before filing

A `task` label has been created for the PRD task template.

## Notes

- An earlier version of this change was pushed directly to `main` by mistake (`cfd6542`); that commit has been reverted and the change now goes through the PR process per the repo's collaboration rules.
- Templates are repo metadata only — no application code is affected.