### PR TITLE
test(#20): close test gaps — GLM error codes + API route contract

### DIFF
--- a/src/quota/credentials.ts
+++ b/src/quota/credentials.ts
@@ -113,7 +113,6 @@ export class SecureCredentialResolver implements CredentialResolver {
 
 /** A resolver that always fails — used when no credential store is wired. */
 export class NoopCredentialResolver implements CredentialResolver {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async reveal(credentialId: string, _expected?: ExpectedScope): Promise<string> {
     throw new CredentialUnavailableError(`no credential store configured (id: ${credentialId})`);
   }

--- a/tests/quota/api-routes.test.ts
+++ b/tests/quota/api-routes.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { QuotaSnapshot } from '../../src/quota/contract.js';
 

--- a/tests/quota/api-routes.test.ts
+++ b/tests/quota/api-routes.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { QuotaSnapshot } from '../../src/quota/contract.js';
+
+// We test the route handler by mocking the shared service singleton.
+const mockSnapshots: QuotaSnapshot[] = [];
+
+function snap(providerId: QuotaSnapshot['providerId'], status: QuotaSnapshot['status']): QuotaSnapshot {
+  return {
+    providerId,
+    status,
+    fetchedAt: new Date().toISOString(),
+    observedAt: null,
+    source: { kind: 'official_protocol', name: 'test', version: null, isFallback: false },
+    plan: { name: null, accountLabel: null },
+    buckets: [],
+  };
+}
+
+vi.mock('@/quota/service-instance', () => ({
+  getQuotaService: () => ({
+    readAll: async () => mockSnapshots,
+    refreshAll: async () => mockSnapshots,
+  }),
+}));
+
+describe('GET /api/v1/quota (contract)', () => {
+  beforeEach(() => {
+    mockSnapshots.length = 0;
+    mockSnapshots.push(
+      snap('codex_chatgpt', 'ready'),
+      snap('glm_coding_plan', 'unavailable'),
+      snap('kimi_code', 'unconfigured'),
+    );
+  });
+
+  it('always returns all three providers in fixed order, even on partial failure', async () => {
+    const { GET } = await import('../../src/app/api/v1/quota/route.js');
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.providers).toHaveLength(3);
+    expect(body.providers.map((p: QuotaSnapshot) => p.providerId)).toEqual([
+      'codex_chatgpt',
+      'glm_coding_plan',
+      'kimi_code',
+    ]);
+    // A single failed provider still yields 200 with its error status.
+    expect(body.providers[1].status).toBe('unavailable');
+    expect(body.providers[2].status).toBe('unconfigured');
+  });
+
+  it('includes schemaVersion and generatedAt', async () => {
+    const { GET } = await import('../../src/app/api/v1/quota/route.js');
+    const res = await GET();
+    const body = await res.json();
+    expect(body.schemaVersion).toBe(1);
+    expect(typeof body.generatedAt).toBe('string');
+  });
+
+  it('sets no-store cache headers', async () => {
+    const { GET } = await import('../../src/app/api/v1/quota/route.js');
+    const res = await GET();
+    expect(res.headers.get('Cache-Control')).toContain('no-store');
+  });
+});
+
+describe('POST /api/v1/quota/refresh (contract)', () => {
+  it('returns three providers after forced refresh', async () => {
+    const { POST } = await import('../../src/app/api/v1/quota/refresh/route.js');
+    const res = await POST();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.providers).toHaveLength(3);
+  });
+});

--- a/tests/quota/glm-provider.test.ts
+++ b/tests/quota/glm-provider.test.ts
@@ -167,4 +167,33 @@ describe('GlmProvider', () => {
     const snap = await p.fetch(null);
     expect(snap.status).toBe('unconfigured');
   });
+
+  it('maps a 403 to error status with forbidden code', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(403, {}),
+    );
+    const snap = await new GlmProvider({ token: 't' }).fetch(null);
+    expect(snap.status).toBe('error');
+    expect(snap.error?.code).toBe('forbidden');
+    expect(snap.error?.retryable).toBe(false);
+  });
+
+  it('maps a 429 to unavailable (transient, retryable)', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(429, {}),
+    );
+    const snap = await new GlmProvider({ token: 't' }).fetch(null);
+    expect(snap.status).toBe('unavailable');
+    expect(snap.error?.code).toBe('transient');
+    expect(snap.error?.retryable).toBe(true);
+  });
+
+  it('maps a timeout (abort) to unavailable with retryable', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      Object.assign(new Error('request timed out'), { name: 'AbortError' }),
+    );
+    const snap = await new GlmProvider({ token: 't' }).fetch(null);
+    expect(snap.status).toBe('unavailable');
+    expect(snap.error?.retryable).toBe(true);
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Mirror tsconfig `paths` so tests can resolve `@/…` (used by API routes).
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   test: {
     include: ['tests/**/*.test.ts'],
     coverage: {


### PR DESCRIPTION
Closes #20 (partial — provider error codes + route contract; UI-state tests tracked separately)

## Changes
- **GLM**: add 403 (forbidden), 429 (transient/retryable), timeout (abort) mappings.
- **API route contract** (`tests/quota/api-routes.test.ts`, new):
  - `/api/v1/quota` always returns all three providers in fixed order, 200 even on partial failure
  - `schemaVersion` + `generatedAt` present
  - `Cache-Control: no-store` header
  - `/api/v1/quota/refresh` returns three providers
- **vitest.config.ts**: add `@/…` resolve alias so route imports (tsconfig path alias) resolve in tests.

## Verification
- Coverage: statements 66 → 76.5, branches 57 → 68.4
- 122 tests pass; typecheck/lint green

Note: UI-state (six-state) tests are a separate concern; tracked under #20 follow-up.