### PR TITLE
feat(#40): Support Kimi Code Console API key as first-class credential

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -83,20 +83,26 @@ GLM_CODING_PLAN_REGION=zai
 
 Restart `npm run dev`. The GLM card then shows real data (5-hour token window + monthly MCP tool-call quota).
 
-### Kimi Code — usually no config
+### Kimi Code — API key or CLI login, your choice
 
-As long as you've installed and logged into the Kimi CLI, Usage-Bar reads `~/.kimi-code/credentials/` automatically and refreshes the token when it expires (tokens last 15 minutes and auto-renew). **Nothing to configure.**
+**Option 1: Console API key (simplest, no Kimi CLI required)**
+
+Kimi members can create API keys in the Kimi Code Console (up to 5, intended for third-party tools — see the [official docs](https://www.kimi.com/code/docs/en/)). Set it in `.env.local` and restart:
+
+```bash
+KIMI_CODE_ACCESS_TOKEN=your-console-api-key
+```
+
+**Option 2: Kimi CLI login state (auto-refresh)**
+
+If you've installed and logged into the Kimi CLI, Usage-Bar reads `~/.kimi-code/credentials/` automatically and refreshes the token when it expires (OAuth tokens last 15 minutes and auto-renew). Nothing to configure.
 
 ```bash
 # If you haven't logged in:
 kimi login
 ```
 
-> ⚠️ **KIMI_CODE_ACCESS_TOKEN does not auto-renew.** Auto-refresh only works when using the CLI's credential file path. If you set `KIMI_CODE_ACCESS_TOKEN` explicitly, it won't refresh after expiry — you'll need to replace it manually.
-> ```bash
-> # Fallback only (no auto-renewal) when the credential file path is unavailable:
-> KIMI_CODE_ACCESS_TOKEN=your-kimi-code-access-token
-> ```
+> ⚠️ `KIMI_CODE_ACCESS_TOKEN` does not auto-renew. If the key is revoked or stops working, the card shows `api_key_invalid` — create a new key in the Console and replace it manually. Auto-refresh only works in CLI credential-file mode.
 
 ### Configuration summary
 
@@ -104,7 +110,7 @@ kimi login
 |---|---|---|
 | **Codex** | ❌ No | Just be logged into Codex (auto-reads App Server) |
 | **GLM** | ✅ Yes | Set `GLM_CODING_PLAN_TOKEN` in `.env.local` |
-| **Kimi** | ❌ Usually no | `kimi login` (auto-read + auto-refresh) |
+| **Kimi** | ❌ Usually no | Console API key (`KIMI_CODE_ACCESS_TOKEN`) or `kimi login` (auto-read + auto-refresh) |
 
 **Note**: Kimi Code usage ≠ Moonshot Open Platform balance — they are not interchangeable.
 
@@ -138,12 +144,12 @@ Check:
 </details>
 
 <details>
-<summary><b>Kimi shows token_expired</b></summary>
+<summary><b>Kimi shows token_expired / api_key_invalid</b></summary>
 
 Depends on your configuration:
 
-- **Using `KIMI_CODE_ACCESS_TOKEN`**: this env var **does not auto-renew**. Replace it with a fresh token, or remove the env var and restart Usage-Bar to fall back to the CLI credential mode (which supports auto-refresh).
-- **Using the CLI credential file** (default): run `kimi login` to re-authenticate.
+- **Using `KIMI_CODE_ACCESS_TOKEN` (Console API key)**: `api_key_invalid` means the key is invalid or revoked. This env var **does not auto-renew** — create a new key in the Kimi Code Console and replace it, or remove the env var and restart Usage-Bar to switch to CLI credential mode (which supports auto-refresh).
+- **Using the CLI credential file**: `token_expired` means the login state is no longer valid — run `kimi login` to re-authenticate.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -83,20 +83,26 @@ GLM_CODING_PLAN_REGION=zai
 
 重启 `npm run dev` 后，GLM 卡片即显示真实数据（5 小时 token 窗口 + MCP 工具月度调用量）。
 
-### Kimi Code —— 通常无需配置
+### Kimi Code —— API Key 或 CLI 登录均可
 
-只要你在本机装过 Kimi CLI 并登录过，Usage-Bar 会自动读取 `~/.kimi-code/credentials/` 的登录态，并在 token 过期时自动刷新（Kimi token 15 分钟过期，自动 renew），**无需配置**。
+**方式一：Console API Key（最简单，无需安装 Kimi CLI）**
+
+Kimi 会员可在 Kimi Code Console 创建 API Key（最多 5 个，供第三方工具使用，见[官方文档](https://www.kimi.com/code/docs/en/)）。在 `.env.local` 中设置后重启即可：
+
+```bash
+KIMI_CODE_ACCESS_TOKEN=你的-console-api-key
+```
+
+**方式二：Kimi CLI 登录态（自动刷新）**
+
+如果你本机装过 Kimi CLI 并登录过，Usage-Bar 会自动读取 `~/.kimi-code/credentials/` 的登录态，并在 token 过期时自动刷新（Kimi OAuth token 15 分钟过期，自动 renew），无需配置。
 
 ```bash
 # 如果没登录过，先登录：
 kimi login
 ```
 
-> ⚠️ **KIMI_CODE_ACCESS_TOKEN 不会自动续期**。自动刷新（refresh）只有当你使用 CLI 的 credential 文件路径时才有效。如果你显式设置了 `KIMI_CODE_ACCESS_TOKEN`，它过期后不会再自动更新，需要你手动换新的。
-> ```bash
-> # 仅在 credential 文件路径不可用时的备选（不自动续期）：
-> KIMI_CODE_ACCESS_TOKEN=你的-kimi-code-access-token
-> ```
+> ⚠️ `KIMI_CODE_ACCESS_TOKEN` 不会自动续期。API key 被吊销或失效后，卡片会显示 `api_key_invalid`，需在 Console 重新创建并手动替换。自动刷新只在 CLI credential 文件模式下有效。
 
 ### 配置一览
 
@@ -104,7 +110,7 @@ kimi login
 |---|---|---|
 | **Codex** | ❌ 不用 | 登录过 Codex 即可（自动读 App Server） |
 | **GLM** | ✅ 需要 | `.env.local` 设 `GLM_CODING_PLAN_TOKEN` |
-| **Kimi** | ❌ 通常不用 | `kimi login` 即可（自动读 + 自动刷新） |
+| **Kimi** | ❌ 通常不用 | Console API Key（设 `KIMI_CODE_ACCESS_TOKEN`）或 `kimi login`（自动读 + 自动刷新） |
 
 **注意**：Kimi Code 用量 ≠ Moonshot Open Platform 余额，二者不可混用。
 
@@ -138,12 +144,12 @@ CODEX_BINARY_PATH=...           # 指定 codex 二进制路径
 </details>
 
 <details>
-<summary><b>Kimi 卡片显示 token_expired</b></summary>
+<summary><b>Kimi 卡片显示 token_expired / api_key_invalid</b></summary>
 
 取决于你的配置方式：
 
-- **使用 `KIMI_CODE_ACCESS_TOKEN`**：该环境变量**不会自动续期**。替换为新 token，或删除该环境变量后重启 Usage-Bar，使其回到 CLI credential 模式（支持自动刷新）。
-- **使用 CLI credential 文件**（默认）：运行 `kimi login` 重新登录即可。
+- **使用 `KIMI_CODE_ACCESS_TOKEN`（Console API Key）**：显示 `api_key_invalid` 说明 key 失效或被吊销。该环境变量**不会自动续期**——到 Kimi Code Console 重新创建 key 并替换；或删除该环境变量后重启 Usage-Bar，改用 CLI credential 模式（支持自动刷新）。
+- **使用 CLI credential 文件**：显示 `token_expired` 说明登录态失效，运行 `kimi login` 重新登录即可。
 </details>
 
 <details>

--- a/src/quota/providers/kimi.ts
+++ b/src/quota/providers/kimi.ts
@@ -201,20 +201,20 @@ export class KimiProvider implements QuotaProviderAdapter {
     credentialId: string,
   ): Promise<{ token: string; kind: KimiCredentialKind }> {
     if (!this.resolver) throw new Error('credentialId set but no resolver provided');
-    let mismatch: unknown;
     for (const scope of EXPECTED_SCOPES) {
       try {
         const token = await this.resolver.reveal(credentialId, scope);
         return { token, kind: scope.kind as KimiCredentialKind };
       } catch (err) {
-        if (err instanceof CredentialScopeMismatchError) {
-          mismatch = err;
-          continue;
-        }
-        throw err;
+        // A kind mismatch falls through to the next accepted kind; any other
+        // failure (missing, revoked) aborts immediately.
+        if (!(err instanceof CredentialScopeMismatchError)) throw err;
       }
     }
-    throw mismatch ?? new Error('no acceptable credential kind');
+    // Every accepted kind mismatched — the credential is not usable here.
+    throw new CredentialScopeMismatchError(
+      `credential matches none of the accepted kinds (id: ${credentialId})`,
+    );
   }
 
   // -----------------------------------------------------------------

--- a/src/quota/providers/kimi.ts
+++ b/src/quota/providers/kimi.ts
@@ -3,8 +3,13 @@
 // Kimi Code quota provider (official_compatibility).
 //
 // Endpoint: GET https://api.kimi.com/coding/v1/usages
-// Auth: Bearer <accessToken> — the Kimi Code OAuth access token, obtained via
-// the device-code flow by kimi-cli and stored at ~/.kimi-code/credentials/.
+// Auth: Bearer <credential> — two first-class credential kinds (#40):
+//   1. api_key: a Console-issued API key (Kimi Code Console → API Keys), passed
+//      via KIMI_CODE_ACCESS_TOKEN or a credentialId. Static: NEVER sent through
+//      the OAuth refresh flow; a 401 means the key is invalid/revoked.
+//   2. oauth_token: the Kimi CLI OAuth access token, obtained via the
+//      device-code flow and stored at ~/.kimi-code/credentials/. Short-lived
+//      (~15min) and auto-refreshed via the stored refresh_token (#15).
 // This is the KIMI CODE subscription usage, NOT Moonshot Open Platform balance
 // (PRD §7.3 explicitly forbids substituting the latter).
 //
@@ -21,7 +26,11 @@ import {
   kimiUsagesResponseSchema,
   type KimiUsagesResponseParsed,
 } from '../schemas.js';
-import type { CredentialResolver, ExpectedScope } from '../credentials.js';
+import {
+  CredentialScopeMismatchError,
+  type CredentialResolver,
+  type ExpectedScope,
+} from '../credentials.js';
 import type {
   QuotaBucket,
   QuotaBalance,
@@ -30,7 +39,7 @@ import type {
 } from '../contract.js';
 
 export interface KimiProviderConfig {
-  /** Access token override; otherwise read from kimi-cli credentials. env fallback. */
+  /** Console API key (or static token) override; otherwise read from kimi-cli credentials. env fallback. */
   accessToken?: string;
   /** A credentialId resolved via `resolver` with scope validation (#22). */
   credentialId?: string;
@@ -42,7 +51,16 @@ export interface KimiProviderConfig {
   baseUrl?: string;
 }
 
-const EXPECTED_SCOPE: ExpectedScope = { provider: 'kimi_code', kind: 'oauth_token' };
+/** The two credential kinds this adapter accepts (#40). */
+type KimiCredentialKind = 'api_key' | 'oauth_token';
+
+// credentialId credentials may be stored as either kind; both are valid for
+// /usages. Scope validation tries each in turn — a kind mismatch falls through
+// to the next, any other failure (missing/revoked) aborts immediately.
+const EXPECTED_SCOPES: ExpectedScope[] = [
+  { provider: 'kimi_code', kind: 'api_key' },
+  { provider: 'kimi_code', kind: 'oauth_token' },
+];
 
 const PROVIDER_ID = 'kimi_code' as const;
 const DISPLAY_NAME = 'Kimi Code';
@@ -95,22 +113,26 @@ export class KimiProvider implements QuotaProviderAdapter {
   async fetch(previous: QuotaSnapshot | null): Promise<QuotaSnapshot> {
     const fetchedAt = new Date().toISOString();
 
-    // Resolve a valid access token, refreshing via OAuth if necessary (#15).
-    let token: string;
+    // Resolve a usable credential. OAuth tokens are refreshed via OAuth if
+    // necessary (#15); API keys are used as-is and never refreshed (#40).
+    let cred: { token: string; kind: KimiCredentialKind };
     try {
-      token = await this.resolveAccessToken();
+      cred = await this.resolveAccessToken();
     } catch {
       return empty(fetchedAt, previous, {
         code: 'token_expired',
-        safeMessage: 'Kimi Code token expired or revoked. Re-login via kimi-cli.',
+        safeMessage: this.credentialId
+          ? 'Kimi Code credential could not be resolved (missing, revoked, or wrong scope).'
+          : 'Kimi Code token expired or revoked. Run `kimi login` to re-authenticate.',
         retryable: false,
       }, 'unconfigured');
     }
 
-    if (!token) {
+    if (!cred.token) {
       return empty(fetchedAt, previous, {
         code: 'no_credentials',
-        safeMessage: 'Kimi Code not logged in. Run kimi-cli login.',
+        safeMessage:
+          'Kimi Code not configured. Set KIMI_CODE_ACCESS_TOKEN to a Kimi Code Console API key, or run `kimi login`.',
         retryable: false,
       }, 'unconfigured');
     }
@@ -118,45 +140,61 @@ export class KimiProvider implements QuotaProviderAdapter {
     try {
       const result = await fetchJson<unknown>('kimi', `${this.baseUrl}/usages`, {
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${cred.token}`,
           Accept: 'application/json',
         },
       });
       const parsed = parseWithSchema('kimi', kimiUsagesResponseSchema, result.value);
       return this.toSnapshot(parsed, fetchedAt, previous);
     } catch (err) {
-      return this.toErrorSnapshot(err, fetchedAt, previous);
+      return this.toErrorSnapshot(err, fetchedAt, previous, cred.kind);
     }
   }
 
   /**
-   * Resolve a valid access token. If an override is configured, use it as-is.
-   * Otherwise read the credentials file; if the stored token is expired (or
-   * near expiry), refresh it via the OAuth refresh_token grant and write the
-   * refreshed credentials back so kimi-cli and this app stay in sync (#15).
+   * Resolve a usable credential and its kind. A credentialId may be stored as
+   * either an API key or an OAuth token (both are accepted, #40); an explicit
+   * accessToken override is treated as a static API key and used as-is.
+   * Otherwise read the CLI credentials file; if the stored token is expired
+   * (or near expiry), refresh it via the OAuth refresh_token grant and write
+   * the refreshed credentials back so kimi-cli and this app stay in sync (#15).
    * Throws if no usable token can be obtained.
    */
-  private async resolveAccessToken(): Promise<string> {
-    // credentialId takes precedence: resolve + scope-validate via the resolver.
+  private async resolveAccessToken(): Promise<{ token: string; kind: KimiCredentialKind }> {
+    // credentialId takes precedence: resolve + scope-validate via the resolver,
+    // accepting either credential kind.
     if (this.credentialId) {
       if (!this.resolver) throw new Error('credentialId set but no resolver provided');
-      return this.resolver.reveal(this.credentialId, EXPECTED_SCOPE);
+      let mismatch: unknown;
+      for (const scope of EXPECTED_SCOPES) {
+        try {
+          const token = await this.resolver.reveal(this.credentialId, scope);
+          return { token, kind: scope.kind as KimiCredentialKind };
+        } catch (err) {
+          if (err instanceof CredentialScopeMismatchError) {
+            mismatch = err;
+            continue;
+          }
+          throw err;
+        }
+      }
+      throw mismatch ?? new Error('no acceptable credential kind');
     }
-    if (this.accessTokenOverride) return this.accessTokenOverride;
+    if (this.accessTokenOverride) return { token: this.accessTokenOverride, kind: 'api_key' };
 
     const creds = readCredentials(this.credentialsPath);
-    if (!creds.access_token && !creds.refresh_token) return '';
+    if (!creds.access_token && !creds.refresh_token) return { token: '', kind: 'oauth_token' };
 
     // Use the stored token if it is still valid.
     if (creds.access_token && !isExpired(creds)) {
-      return creds.access_token;
+      return { token: creds.access_token, kind: 'oauth_token' };
     }
 
     // Token expired or missing. If there's no refresh_token, fall back to the
     // (stale) access_token — the usages request will likely 401, which maps to
-    // a safe error. The guard at line 132 guarantees access_token is set here.
+    // a safe error. The guard above guarantees access_token is set here.
     if (!creds.refresh_token) {
-      return creds.access_token as string;
+      return { token: creds.access_token as string, kind: 'oauth_token' };
     }
 
     // Refresh via OAuth, then persist so kimi-cli stays in sync.
@@ -167,7 +205,7 @@ export class KimiProvider implements QuotaProviderAdapter {
     if (!refreshed.access_token) {
       throw new Error('kimi oauth refresh returned no access_token');
     }
-    return refreshed.access_token;
+    return { token: refreshed.access_token, kind: 'oauth_token' };
   }
 
   // -----------------------------------------------------------------
@@ -231,8 +269,9 @@ export class KimiProvider implements QuotaProviderAdapter {
     err: unknown,
     fetchedAt: string,
     previous: QuotaSnapshot | null,
+    kind: KimiCredentialKind,
   ): QuotaSnapshot {
-    const { code, message, retryable, status } = classifyKimiError(err);
+    const { code, message, retryable, status } = classifyKimiError(err, kind);
     if (previous && previous.status === 'ready') {
       return { ...previous, status: 'stale', fetchedAt, error: { code, safeMessage: message, retryable } };
     }
@@ -366,7 +405,10 @@ function writeCredentials(path: string, creds: StoredCredentials): void {
 // Error classification (PRD §7.3: OAuth/token expiry → safe state)
 // ---------------------------------------------------------------------------
 
-function classifyKimiError(err: unknown): {
+function classifyKimiError(
+  err: unknown,
+  kind: KimiCredentialKind,
+): {
   code: string;
   message: string;
   retryable: boolean;
@@ -374,7 +416,18 @@ function classifyKimiError(err: unknown): {
 } {
   const e = err as { statusCode?: number; message?: string; isRetryable?: boolean };
   if (e.statusCode === 401) {
-    return { code: 'token_expired', message: 'Kimi Code token expired or revoked. Re-login.', retryable: false, status: 'unconfigured' };
+    // A 401 on a static API key is terminal: keys don't expire on a timer, so
+    // the key was revoked or is wrong — point the user at the Console (#40).
+    if (kind === 'api_key') {
+      return {
+        code: 'api_key_invalid',
+        message:
+          'Kimi Code API key invalid or revoked. Create a new key in the Kimi Code Console and update KIMI_CODE_ACCESS_TOKEN.',
+        retryable: false,
+        status: 'unconfigured',
+      };
+    }
+    return { code: 'token_expired', message: 'Kimi Code token expired or revoked. Run `kimi login` to re-authenticate.', retryable: false, status: 'unconfigured' };
   }
   if (e.statusCode === 403) {
     return { code: 'forbidden', message: 'Kimi Code access denied.', retryable: false, status: 'error' };

--- a/src/quota/providers/kimi.ts
+++ b/src/quota/providers/kimi.ts
@@ -163,23 +163,7 @@ export class KimiProvider implements QuotaProviderAdapter {
   private async resolveAccessToken(): Promise<{ token: string; kind: KimiCredentialKind }> {
     // credentialId takes precedence: resolve + scope-validate via the resolver,
     // accepting either credential kind.
-    if (this.credentialId) {
-      if (!this.resolver) throw new Error('credentialId set but no resolver provided');
-      let mismatch: unknown;
-      for (const scope of EXPECTED_SCOPES) {
-        try {
-          const token = await this.resolver.reveal(this.credentialId, scope);
-          return { token, kind: scope.kind as KimiCredentialKind };
-        } catch (err) {
-          if (err instanceof CredentialScopeMismatchError) {
-            mismatch = err;
-            continue;
-          }
-          throw err;
-        }
-      }
-      throw mismatch ?? new Error('no acceptable credential kind');
-    }
+    if (this.credentialId) return this.resolveCredentialById(this.credentialId);
     if (this.accessTokenOverride) return { token: this.accessTokenOverride, kind: 'api_key' };
 
     const creds = readCredentials(this.credentialsPath);
@@ -206,6 +190,31 @@ export class KimiProvider implements QuotaProviderAdapter {
       throw new Error('kimi oauth refresh returned no access_token');
     }
     return { token: refreshed.access_token, kind: 'oauth_token' };
+  }
+
+  /**
+   * Resolve a credentialId to a token, accepting either credential kind (#40).
+   * A kind mismatch falls through to the next accepted kind; any other failure
+   * (missing, revoked) aborts immediately.
+   */
+  private async resolveCredentialById(
+    credentialId: string,
+  ): Promise<{ token: string; kind: KimiCredentialKind }> {
+    if (!this.resolver) throw new Error('credentialId set but no resolver provided');
+    let mismatch: unknown;
+    for (const scope of EXPECTED_SCOPES) {
+      try {
+        const token = await this.resolver.reveal(credentialId, scope);
+        return { token, kind: scope.kind as KimiCredentialKind };
+      } catch (err) {
+        if (err instanceof CredentialScopeMismatchError) {
+          mismatch = err;
+          continue;
+        }
+        throw err;
+      }
+    }
+    throw mismatch ?? new Error('no acceptable credential kind');
   }
 
   // -----------------------------------------------------------------

--- a/tests/quota/kimi-provider.test.ts
+++ b/tests/quota/kimi-provider.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { KimiProvider } from '../../src/quota/providers/kimi.js';
+import { CredentialScopeMismatchError } from '../../src/quota/credentials.js';
 
 function jsonResponse(status: number, body: unknown): Response {
   return {
@@ -61,14 +62,15 @@ describe('KimiProvider', () => {
     expect(snap.balances![0].amount).toBe(500000);
   });
 
-  it('maps a 401 to unconfigured with token_expired code', async () => {
+  it('maps a 401 on an API key to a non-retryable api_key_invalid state (#40)', async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
       jsonResponse(401, {}),
     );
     const snap = await new KimiProvider({ accessToken: 'tok' }).fetch(null);
     expect(snap.status).toBe('unconfigured');
-    expect(snap.error?.code).toBe('token_expired');
+    expect(snap.error?.code).toBe('api_key_invalid');
     expect(snap.error?.retryable).toBe(false);
+    expect(snap.error?.safeMessage).toContain('Console');
   });
 
   it('returns unconfigured when no access token is available', async () => {
@@ -123,9 +125,9 @@ describe('KimiProvider', () => {
     expect(snap.status).toBe('ready');
   });
 
-  it('resolves the access token via credentialId with scope validation (#22)', async () => {
+  it('resolves the access token via credentialId with scope validation (#22, #40)', async () => {
     const resolver = {
-      reveal: vi.fn().mockResolvedValue('resolved-oauth-token'),
+      reveal: vi.fn().mockResolvedValue('resolved-api-key'),
     };
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
       jsonResponse(200, { usage: { used: '9', limit: '100' } }),
@@ -134,12 +136,49 @@ describe('KimiProvider', () => {
     const p = new KimiProvider({ credentialId: 'cred-kimi', resolver });
     const snap = await p.fetch(null);
 
+    // API-key kind is tried first; the mock accepts it, so no fallback happens.
+    expect(resolver.reveal).toHaveBeenCalledTimes(1);
     expect(resolver.reveal).toHaveBeenCalledWith('cred-kimi', {
+      provider: 'kimi_code',
+      kind: 'api_key',
+    });
+    expect(snap.status).toBe('ready');
+    expect(snap.buckets[0].used).toBe(9);
+  });
+
+  it('falls back to the oauth_token kind when the credential is not an api_key (#40)', async () => {
+    const resolver = {
+      reveal: vi.fn().mockImplementation(async (_id: string, scope: { kind: string }) => {
+        if (scope.kind === 'api_key') {
+          throw new CredentialScopeMismatchError('kind mismatch');
+        }
+        return 'resolved-oauth-token';
+      }),
+    };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(200, { usage: { used: '4', limit: '100' } }),
+    );
+
+    const p = new KimiProvider({ credentialId: 'cred-kimi', resolver });
+    const snap = await p.fetch(null);
+
+    expect(resolver.reveal).toHaveBeenCalledTimes(2);
+    expect(resolver.reveal).toHaveBeenLastCalledWith('cred-kimi', {
       provider: 'kimi_code',
       kind: 'oauth_token',
     });
     expect(snap.status).toBe('ready');
-    expect(snap.buckets[0].used).toBe(9);
+  });
+
+  it('maps a 401 on a credentialId API key to api_key_invalid (#40)', async () => {
+    const resolver = { reveal: vi.fn().mockResolvedValue('console-key') };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(401, {}),
+    );
+    const snap = await new KimiProvider({ credentialId: 'cred-kimi', resolver }).fetch(null);
+    expect(snap.status).toBe('unconfigured');
+    expect(snap.error?.code).toBe('api_key_invalid');
+    expect(snap.error?.retryable).toBe(false);
   });
 
   it('maps a resolver failure to a safe error without calling usages', async () => {
@@ -228,6 +267,60 @@ describe('KimiProvider', () => {
     expect(snap.buckets[1].label).toBe('2-week');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Console API key auth path (issue #40)
+// ---------------------------------------------------------------------------
+
+describe('KimiProvider Console API key path', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('sends the API key as a Bearer token and never touches the OAuth refresh endpoint', async () => {
+    const mock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    mock.mockResolvedValue(jsonResponse(200, { usage: { used: '1', limit: '10' } }));
+
+    const snap = await new KimiProvider({ accessToken: 'console-api-key' }).fetch(null);
+
+    expect(snap.status).toBe('ready');
+    expect(mock).toHaveBeenCalledTimes(1);
+    const [url, init] = mock.mock.calls[0];
+    expect(String(url)).toContain('/usages');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer console-api-key');
+    expect(String(url)).not.toContain('auth.kimi.com');
+  });
+
+  it('still maps a 401 on the OAuth (CLI file) path to token_expired', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'kimi-creds-'));
+    try {
+      const credsPath = join(dir, 'kimi-code.json');
+      await writeFile(
+        credsPath,
+        JSON.stringify({
+          access_token: 'oauth-tok',
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+        }),
+      );
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+        jsonResponse(401, {}),
+      );
+      const snap = await new KimiProvider({ credentialsPath: credsPath }).fetch(null);
+      expect(snap.status).toBe('unconfigured');
+      expect(snap.error?.code).toBe('token_expired');
+      expect(snap.error?.safeMessage).toContain('kimi login');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 
 // ---------------------------------------------------------------------------
 // OAuth token refresh path (issue #32)

--- a/tests/quota/kimi-provider.test.ts
+++ b/tests/quota/kimi-provider.test.ts
@@ -181,6 +181,17 @@ describe('KimiProvider', () => {
     expect(snap.error?.retryable).toBe(false);
   });
 
+  it('maps a credentialId matching neither accepted kind to unconfigured', async () => {
+    const resolver = {
+      reveal: vi.fn().mockRejectedValue(new CredentialScopeMismatchError('kind mismatch')),
+    };
+    const p = new KimiProvider({ credentialId: 'cred-x', resolver });
+    const snap = await p.fetch(null);
+    expect(snap.status).toBe('unconfigured');
+    expect(resolver.reveal).toHaveBeenCalledTimes(2); // tried both kinds
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   it('maps a resolver failure to a safe error without calling usages', async () => {
     const resolver = { reveal: vi.fn().mockRejectedValue(new Error('revoked')) };
     const p = new KimiProvider({ credentialId: 'cred-bad', resolver });


### PR DESCRIPTION
## Summary

Closes the code side of #40 (live verification with a real Console key still pending — see below).

- **Two first-class credential kinds** in `src/quota/providers/kimi.ts`:
  - `api_key` — Console-issued API key via `KIMI_CODE_ACCESS_TOKEN` or a `credentialId`. Used as-is; **never** sent through the OAuth refresh flow.
  - `oauth_token` — Kimi CLI credentials file (`~/.kimi-code/credentials/`), keeps the existing auto-refresh path (#15).
- **Distinct credential kinds for `credentialId`**: scope validation accepts both `api_key` and `oauth_token`, falling back on kind mismatch.
- **401 mapping**: API key → non-retryable `api_key_invalid` ("create a new key in the Kimi Code Console"); OAuth token → `token_expired` (`kimi login`). No credential material in either message.
- **README**: Kimi CLI is no longer a prerequisite — the Console API key is documented as the simplest path, CLI login kept as the auto-refresh alternative.

## Tests

- API-key path: Bearer header shape, and proof the OAuth refresh endpoint is never touched.
- 401 → `api_key_invalid` (env key and credentialId) vs `token_expired` (CLI OAuth file).
- credentialId: `api_key` kind preferred, `oauth_token` fallback on `CredentialScopeMismatchError`.
- Full suite green: 127 passed, tsc + eslint clean.

## Not done (needs owner)

- [ ] Live check with a real Console-issued API key: set `KIMI_CODE_ACCESS_TOKEN` and run `npm run smoke` — no such key on the maintainer machine; evidence in #40 strongly suggests 200.