### PR TITLE
fix: correct GLM weekly window label

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -81,7 +81,7 @@ GLM_CODING_PLAN_REGION=zai
 
 > ⚠️ `GLM_CODING_PLAN_REGION` must be exactly `bigmodel` or `zai`. Any other value makes the GLM card report a configuration error (with no silent fallback and no impact on Codex/Kimi).
 
-Restart `npm run dev`. The GLM card then shows real data (5-hour token window + monthly MCP tool-call quota).
+Restart `npm run dev`. The GLM card then shows real data (5-hour token window + 7-day weekly token window + monthly MCP tool-call quota).
 
 ### Kimi Code — API key or CLI login, your choice
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ GLM_CODING_PLAN_REGION=zai
 
 > ⚠️ `GLM_CODING_PLAN_REGION` 只能是 `bigmodel` 或 `zai`。其他值会让 GLM 卡片显示配置错误（不会静默回落到默认区域，也不影响 Codex/Kimi）。
 
-重启 `npm run dev` 后，GLM 卡片即显示真实数据（5 小时 token 窗口 + MCP 工具月度调用量）。
+重启 `npm run dev` 后，GLM 卡片即显示真实数据（5 小时 token 窗口 + 7 天 token 周额度 + MCP 工具月度调用量）。
 
 ### Kimi Code —— API Key 或 CLI 登录均可
 

--- a/src/quota/providers/glm.ts
+++ b/src/quota/providers/glm.ts
@@ -221,26 +221,44 @@ function describeGlmWindow(limit: GlmLimit): string {
   // the period shown via its unit/number.
   if (limit.type === 'TIME_LIMIT') {
     const period = limit.unit != null && limit.number != null
-      ? GLM_UNIT_MINUTES_LABEL(limit.unit)
+      ? formatGlmPeriod(limit.unit, limit.number)
       : null;
     return period ? `MCP tools (${period})` : 'MCP tools';
   }
   const typeLabel = limit.type === 'TOKENS_LIMIT' ? 'tokens' : limit.type;
   if (limit.unit != null && limit.number != null) {
-    const unitName = GLM_UNIT_MINUTES_LABEL(limit.unit);
-    return `${limit.number}-${unitName} (${typeLabel})`;
+    const period = formatGlmPeriod(limit.unit, limit.number);
+    return `${period} (${typeLabel})`;
   }
   return typeLabel;
 }
 
-function GLM_UNIT_MINUTES_LABEL(unit: number): string {
-  // Observed: 3=hour, 5=month, 6=day, 7=week
+/**
+ * Map a GLM `unit` enum code to a human period and fold it with the `number`
+ * count into a single readable label, e.g. "5-hour", "7-day", "1-month".
+ *
+ * IMPORTANT: GLM's `unit` is an opaque enum, NOT a minute count. The previous
+ * implementation treated it as minutes-derived and *guessed* the enum
+ * (comment: "6=day, 7=week"), which mislabeled the weekly token window. A real
+ * account returns TOKENS_LIMIT `{ number: 1, unit: 6 }` for the 7-day window —
+ * i.e. `unit 6 = week`, so "1-week" must be folded to "7-day" to match GLM's
+ * own "7天" wording and the reset timestamp (a ~7-day period, not 1-day).
+ *
+ * Verified mapping (real account, monitor API, 2026-08):
+ *   3 = hour     (5-hour token window)
+ *   5 = month    (1-month MCP tools window)
+ *   6 = week     (7-day token window — the bug source)
+ * `4`/`7` are reserved against future drift; unknown codes fall back to an
+ * explicit `unit<n>` so a new code is visibly distinct, never silently wrong.
+ */
+function formatGlmPeriod(unit: number, number: number): string {
   switch (unit) {
-    case 3: return 'hour';
-    case 5: return 'month';
-    case 6: return 'day';
-    case 7: return 'week';
-    default: return `unit${unit}`;
+    case 3: return `${number}-hour`;
+    case 4: return `${number}-day`;
+    case 5: return `${number}-month`;
+    case 6: return number === 1 ? '7-day' : `${number}-week`;
+    case 7: return `${number}-week`;
+    default: return `${number}-unit${unit}`;
   }
 }
 

--- a/src/quota/providers/glm.ts
+++ b/src/quota/providers/glm.ts
@@ -244,20 +244,19 @@ function describeGlmWindow(limit: GlmLimit): string {
  * i.e. `unit 6 = week`, so "1-week" must be folded to "7-day" to match GLM's
  * own "7天" wording and the reset timestamp (a ~7-day period, not 1-day).
  *
- * Verified mapping (real account, monitor API, 2026-08):
+ * Only the codes seen on a real account are mapped (2026-08):
  *   3 = hour     (5-hour token window)
  *   5 = month    (1-month MCP tools window)
  *   6 = week     (7-day token window — the bug source)
- * `4`/`7` are reserved against future drift; unknown codes fall back to an
- * explicit `unit<n>` so a new code is visibly distinct, never silently wrong.
+ * Any other code falls through to an explicit `N-unit<code>` label so a new
+ * code is visibly distinct and never silently mislabeled. We deliberately do
+ * NOT guess adjacent codes (e.g. 4=day) — guessing is exactly what caused #42.
  */
 function formatGlmPeriod(unit: number, number: number): string {
   switch (unit) {
     case 3: return `${number}-hour`;
-    case 4: return `${number}-day`;
     case 5: return `${number}-month`;
     case 6: return number === 1 ? '7-day' : `${number}-week`;
-    case 7: return `${number}-week`;
     default: return `${number}-unit${unit}`;
   }
 }

--- a/tests/quota/glm-provider.test.ts
+++ b/tests/quota/glm-provider.test.ts
@@ -98,6 +98,29 @@ describe('GlmProvider', () => {
     expect(snap.buckets[0].label).toBe('2-week (tokens)');
   });
 
+  it('renders an unknown unit code as an explicit, non-guessed label', async () => {
+    // An unseen unit code must NOT be guessed (that caused #42) — it falls
+    // through to a visibly distinct `N-unit<code>` label instead.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(200, {
+        data: { limits: [{ type: 'TOKENS_LIMIT', unit: 99, number: 3, percentage: 1 }] },
+      }),
+    );
+    const snap = await new GlmProvider({ token: 'tok' }).fetch(null);
+    expect(snap.buckets[0].label).toBe('3-unit99 (tokens)');
+  });
+
+  it('labels a TOKENS_LIMIT without unit/number as just the type', async () => {
+    // Covers the no-period branch for the tokens path (unit/number absent).
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(200, {
+        data: { limits: [{ type: 'TOKENS_LIMIT', percentage: 7 }] },
+      }),
+    );
+    const snap = await new GlmProvider({ token: 'tok' }).fetch(null);
+    expect(snap.buckets[0].label).toBe('tokens');
+  });
+
   it('labels a TIME_LIMIT without unit/number as plain "MCP tools"', async () => {
     // Covers the no-period branch: unit/number absent → label has no "(period)".
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(

--- a/tests/quota/glm-provider.test.ts
+++ b/tests/quota/glm-provider.test.ts
@@ -24,18 +24,25 @@ describe('GlmProvider', () => {
   });
 
   it('maps a normal multi-window response to ready buckets', async () => {
+    // Fixture mirrors a REAL account's monitor API response (3 windows):
+    //   TIME_LIMIT  {number:1, unit:5}  → MCP tools, monthly
+    //   TOKENS_LIMIT{number:5, unit:3}  → 5-hour token window
+    //   TOKENS_LIMIT{number:1, unit:6}  → 7-day token window (the bug source)
+    // unit is an opaque enum, NOT minutes: 3=hour, 5=month, 6=week (#42).
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
       jsonResponse(200, {
         data: {
           limits: [
-            { type: 'TOKENS_LIMIT', unit: 3, number: 5, percentage: 42, nextResetTime: 1785436421682 },
             {
               type: 'TIME_LIMIT', unit: 5, number: 1, percentage: 1, currentValue: 5, usage: 4000,
               usageDetails: [
                 { modelCode: 'search-prime', usage: 3 },
                 { modelCode: 'web-reader', usage: 2 },
               ],
+              nextResetTime: 1787676680997,
             },
+            { type: 'TOKENS_LIMIT', unit: 3, number: 5, percentage: 1, nextResetTime: 1785949413655 },
+            { type: 'TOKENS_LIMIT', unit: 6, number: 1, percentage: 6, nextResetTime: 1786207880998 },
           ],
         },
       }),
@@ -44,19 +51,51 @@ describe('GlmProvider', () => {
     const snap = await new GlmProvider({ token: 'tok' }).fetch(null);
     expect(snap.status).toBe('ready');
     expect(snap.source.kind).toBe('official_compatibility');
-    expect(snap.buckets).toHaveLength(2);
-    expect(snap.buckets[0].usedPercent).toBe(42);
-    expect(snap.buckets[0].resetsAt).toContain('2026');
+    expect(snap.buckets).toHaveLength(3);
 
     // TIME_LIMIT is MCP tools usage (联网搜索/网页读取/开源仓库) — a monthly
     // internet/tool-call quota, NOT a monthly token quota (#37).
-    const mcp = snap.buckets[1];
-    expect(mcp.label).toBe('MCP tools (month)');
+    const mcp = snap.buckets[0];
+    expect(mcp.label).toBe('MCP tools (1-month)');
     expect(mcp.metric).toBe('requests');
     expect(mcp.used).toBe(5);
     expect(mcp.limit).toBe(4000);
     // usageDetails surfaced as a readable breakdown (#37).
     expect(mcp.details).toBe('search-prime=3, web-reader=2');
+
+    // 5-hour token window (unit 3 = hour).
+    expect(snap.buckets[1].label).toBe('5-hour (tokens)');
+
+    // 7-day token window (unit 6 = week; "1-week" folded to "7-day" to match
+    // GLM's own "7天" wording). Previously mislabeled as "1-day" (#42).
+    expect(snap.buckets[2].label).toBe('7-day (tokens)');
+    expect(snap.buckets[2].usedPercent).toBe(6);
+    expect(snap.buckets[2].resetsAt).toContain('2026');
+  });
+
+  it('labels a 1-week token window as "7-day" (GLM "7天" wording)', async () => {
+    // Regression guard for the weekly-window mislabel (#42). The previous
+    // mapping guessed unit 6 = 'day', so {number:1, unit:6} rendered as
+    // "1-day". Real semantics: unit 6 = week, and 1-week → "7-day".
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(200, {
+        data: { limits: [{ type: 'TOKENS_LIMIT', unit: 6, number: 1, percentage: 6 }] },
+      }),
+    );
+    const snap = await new GlmProvider({ token: 'tok' }).fetch(null);
+    expect(snap.buckets[0].label).toBe('7-day (tokens)');
+  });
+
+  it('labels a multi-week window with its count rather than folding to days', async () => {
+    // Only "1-week" folds to "7-day"; a 2-week window keeps "2-week" so the
+    // count is honest and not ambiguously large in days.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      jsonResponse(200, {
+        data: { limits: [{ type: 'TOKENS_LIMIT', unit: 6, number: 2, percentage: 10 }] },
+      }),
+    );
+    const snap = await new GlmProvider({ token: 'tok' }).fetch(null);
+    expect(snap.buckets[0].label).toBe('2-week (tokens)');
   });
 
   it('labels a TIME_LIMIT without unit/number as plain "MCP tools"', async () => {


### PR DESCRIPTION
## Root cause

GLM's 7-day token window rendered as **"1-day"**. The provider guessed the API's opaque integer `unit` mapping as `6 = day` and assembled the label as `${number}-${unit}`. A real account returns `TOKENS_LIMIT { number: 1, unit: 6 }` for the weekly window, and its reset timestamp was roughly 73 hours away, proving that the window could not be one day.

The mislabel shipped because no fixture exercised a weekly `TOKENS_LIMIT` window.

## Fix

Verified the mapping against a live account through `GET /api/monitor/usage/quota/limit`, inspecting only the allowlisted fields `{ type, number, unit, percentage, nextResetTime }`:

- `3 = hour` for the 5-hour token window;
- `5 = month` for the monthly MCP tools window;
- `6 = week` for the 7-day token window.

`glm.ts` now formats the complete period from `unit` and `number`, maps `1 week` to GLM's own `7-day` wording, preserves multi-week counts, and renders unverified unit codes as explicit `N-unit<code>` labels instead of guessing.

The GLM provider fixture now mirrors the real three-window response and includes regression coverage for the 7-day window, multi-week formatting, unknown units, and missing period fields.

The Chinese and English READMEs now document all three displayed GLM quotas: the 5-hour token window, the 7-day token window, and the monthly MCP tools quota.

No schema, other provider, or UI behavior changes are required; the UI already renders `bucket.label`.

## Verified

- 143 tests passed; 4 opt-in smoke tests skipped;
- lint, typecheck, production build, and coverage passed;
- Codecov reports 100% patch coverage;
- SonarCloud Quality Gate passed with 0 new issues and 0 security hotspots.